### PR TITLE
las-371-add-single-image-upload-to-fe

### DIFF
--- a/lib/bloc/cubit/camera_state.dart
+++ b/lib/bloc/cubit/camera_state.dart
@@ -4,6 +4,7 @@ enum UploadMode { unlockedAlbums, singleAlbum }
 
 class CameraState extends Equatable {
   final List<CapturedImage> photosTaken;
+  final List<CapturedImage> photosSelected;
   final int? selectedIndex;
   final CapturedImage? selectedImage;
   final Map<String, Album> albumMap;
@@ -11,8 +12,10 @@ class CameraState extends Equatable {
   final TextEditingController captionTextController;
   final bool loading;
   final UploadMode mode;
+  final CustomException exception;
   const CameraState({
     required this.photosTaken,
+    required this.photosSelected,
     required this.selectedIndex,
     required this.selectedImage,
     required this.albumMap,
@@ -20,11 +23,13 @@ class CameraState extends Equatable {
     required this.captionTextController,
     required this.loading,
     required this.mode,
+    this.exception = CustomException.empty,
   });
 
   factory CameraState.empty() {
     return CameraState(
       photosTaken: const [],
+      photosSelected: const [],
       selectedIndex: null,
       selectedImage: null,
       selectedAlbum: null,
@@ -37,6 +42,7 @@ class CameraState extends Equatable {
 
   CameraState copyWith({
     List<CapturedImage>? photosTaken,
+    List<CapturedImage>? photosSelected,
     int? selectedIndex,
     CapturedImage? selectedImage,
     Map<String, Album>? albumMap,
@@ -44,9 +50,11 @@ class CameraState extends Equatable {
     TextEditingController? captionTextController,
     bool? loading,
     UploadMode? mode,
+    CustomException? exception,
   }) {
     return CameraState(
       photosTaken: photosTaken ?? this.photosTaken,
+      photosSelected: photosSelected ?? this.photosSelected,
       selectedIndex: selectedIndex ?? this.selectedIndex,
       selectedImage: selectedImage ?? this.selectedImage,
       selectedAlbum: selectedAlbum ?? this.selectedAlbum,
@@ -55,11 +63,17 @@ class CameraState extends Equatable {
           captionTextController ?? this.captionTextController,
       loading: loading ?? this.loading,
       mode: mode ?? this.mode,
+      exception: exception ?? this.exception,
     );
   }
 
   List<CapturedImage> get selectedAlbumImageList {
     return List.from(photosTaken
+        .where((element) => element.albumID == selectedAlbum!.albumId));
+  }
+
+  List<CapturedImage> get selectedAlbumSelectedImageList {
+    return List.from(photosSelected
         .where((element) => element.albumID == selectedAlbum!.albumId));
   }
 
@@ -98,6 +112,7 @@ class CameraState extends Equatable {
   @override
   List<Object?> get props => [
         photosTaken,
+        photosSelected,
         selectedIndex,
         selectedAlbum,
         albumMap,
@@ -106,5 +121,6 @@ class CameraState extends Equatable {
         captionTextController,
         loading,
         mode,
+        exception,
       ];
 }

--- a/lib/components/camera_comp/camera_utils/camera_controls.dart
+++ b/lib/components/camera_comp/camera_utils/camera_controls.dart
@@ -1,9 +1,12 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:shared_photo/bloc/cubit/camera_cubit.dart';
 import 'package:shared_photo/components/camera_comp/camera_utils/shutter_button.dart';
 import 'package:shared_photo/components/camera_comp/edit_screen_comp/captured_edit_screen.dart';
+import 'package:shared_photo/models/photo.dart';
+import 'package:shared_photo/screens/captured_image_list_screen.dart';
 
 class CameraControls extends StatefulWidget {
   final CameraController controller;
@@ -44,6 +47,28 @@ class _CameraControlsState extends State<CameraControls> {
 
   @override
   Widget build(BuildContext context) {
+    final ImagePicker imagePicker = ImagePicker();
+
+    void addListPhotos(List<XFile>? selectedImages) {
+      if (selectedImages == null) return;
+
+      context
+          .read<CameraCubit>()
+          .addListOfPhotosToList(selectedImages, UploadType.forgotShot);
+    }
+
+    void pushCapturedPage() {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (ctx) => BlocProvider<CameraCubit>.value(
+            value: context.read<CameraCubit>(),
+            child:
+                const CapturedImageListScreen(), //const CapturedEditScreen(),
+          ),
+        ),
+      );
+    }
+
     return Column(
       children: [
         Row(
@@ -70,18 +95,12 @@ class _CameraControlsState extends State<CameraControls> {
           ],
         ),
         GestureDetector(
-          onTap: () => showModalBottomSheet(
-            context: context,
-            isScrollControlled: true,
-            useSafeArea: true,
-            enableDrag: false,
-            builder: (ctx) {
-              return BlocProvider.value(
-                value: context.read<CameraCubit>(),
-                child: const CapturedEditScreen(),
-              );
-            },
-          ),
+          onTap: () async {
+            List<XFile>? selectedImages = await imagePicker
+                .pickMultiImage()
+                .whenComplete(() => pushCapturedPage());
+            addListPhotos(selectedImages);
+          },
           child: const Icon(
             Icons.library_add,
             color: Colors.white,

--- a/lib/components/camera_comp/camera_utils/shutter_button.dart
+++ b/lib/components/camera_comp/camera_utils/shutter_button.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:camera/camera.dart';
@@ -25,16 +26,12 @@ class ShutterButton extends StatelessWidget {
 
           if (selectedAlbum != null) {
             capImage = CapturedImage(
-              imageXFile: picture,
-              albumID: selectedAlbum.albumId,
-              type: UploadType.snap,
-            );
+                imageXFile: picture,
+                albumID: selectedAlbum.albumId,
+                type: UploadType.snap);
           } else {
             capImage = CapturedImage(
-              imageXFile: picture,
-              addToRecap: true,
-              type: UploadType.snap,
-            );
+                imageXFile: picture, addToRecap: true, type: UploadType.snap);
           }
           context.read<CameraCubit>().addPhotoToList(capImage);
         }

--- a/lib/components/camera_comp/captured_image_list_comp/captured_image_item.dart
+++ b/lib/components/camera_comp/captured_image_list_comp/captured_image_item.dart
@@ -1,13 +1,18 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gap/gap.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_photo/bloc/cubit/camera_cubit.dart';
+import 'package:shared_photo/models/captured_image.dart';
 
 class CapturedImageItem extends StatefulWidget {
-  final String imagePath;
-  const CapturedImageItem({super.key, required this.imagePath});
+  final CapturedImage image;
+  final Key key;
+  const CapturedImageItem({required this.key, required this.image})
+      : super(key: key);
 
   @override
   State<CapturedImageItem> createState() => _CapturedImageItemState();
@@ -15,12 +20,36 @@ class CapturedImageItem extends StatefulWidget {
 
 class _CapturedImageItemState extends State<CapturedImageItem> {
   bool toggle = false;
-  TextEditingController controller = TextEditingController();
+  double? uploadStatus;
+  late StreamSubscription<double> subscription;
+
+  @override
+  void initState() {
+    super.initState();
+
+    subscription = widget.image.uploadStatusController.stream.listen((onData) {
+      print("${onData} from item");
+
+      setState(() {
+        uploadStatus = onData;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    subscription.cancel();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     double rowHeight = MediaQuery.of(context).size.height * .09;
+
     return BlocBuilder<CameraCubit, CameraState>(
       builder: (context, state) {
+        TextEditingController controller =
+            TextEditingController(text: widget.image.caption);
         return Container(
           padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 7),
           margin: const EdgeInsets.symmetric(vertical: 5),
@@ -28,97 +57,111 @@ class _CapturedImageItemState extends State<CapturedImageItem> {
             color: const Color.fromRGBO(19, 19, 19, 1),
             borderRadius: BorderRadius.circular(5),
           ),
-          child: Row(
+          child: Column(
             children: [
-              Container(
-                height: rowHeight,
-                clipBehavior: Clip.hardEdge,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(5),
-                ),
-                child: AspectRatio(
-                  aspectRatio: 5 / 6,
-                  child: Image(
-                    fit: BoxFit.cover,
-                    image: FileImage(
-                      File(widget.imagePath),
+              Row(
+                children: [
+                  Container(
+                    height: rowHeight,
+                    clipBehavior: Clip.hardEdge,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(5),
                     ),
-                  ),
-                ),
-              ),
-              Expanded(
-                child: Container(
-                  height: rowHeight,
-                  padding: const EdgeInsets.only(left: 10, right: 5),
-                  child: TextField(
-                    onTapOutside: (event) =>
-                        FocusManager.instance.primaryFocus?.unfocus(),
-                    controller: controller,
-                    maxLines: null,
-                    expands: true,
-                    textAlignVertical: TextAlignVertical.top,
-                    style: GoogleFonts.montserrat(
-                      color: Colors.white,
-                      fontSize: 15,
-                      fontWeight: FontWeight.w500,
-                    ),
-                    decoration: InputDecoration(
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 8,
-                      ),
-                      hintText: "Add Caption",
-                      hintStyle: GoogleFonts.montserrat(
-                        color: Colors.white54,
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(5),
-                        borderSide: const BorderSide(
-                          color: Color.fromRGBO(19, 19, 19, 1),
+                    child: AspectRatio(
+                      aspectRatio: 5 / 6,
+                      child: Image(
+                        fit: BoxFit.cover,
+                        image: FileImage(
+                          File(widget.image.imageXFile.path),
                         ),
                       ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(5),
-                        borderSide: const BorderSide(
-                          color: Color.fromRGBO(19, 19, 19, 1),
+                    ),
+                  ),
+                  Expanded(
+                    child: Container(
+                      height: rowHeight,
+                      padding: const EdgeInsets.only(left: 10, right: 5),
+                      child: TextField(
+                        onTapOutside: (event) =>
+                            FocusManager.instance.primaryFocus?.unfocus(),
+                        onChanged: (text) => context
+                            .read<CameraCubit>()
+                            .updateImageCaptionWithText(widget.image, text),
+                        controller: controller,
+                        maxLines: null,
+                        expands: true,
+                        textAlignVertical: TextAlignVertical.top,
+                        style: GoogleFonts.montserrat(
+                          color: Colors.white,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w500,
+                        ),
+                        decoration: InputDecoration(
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 8,
+                          ),
+                          hintText: "Add Caption",
+                          hintStyle: GoogleFonts.montserrat(
+                            color: Colors.white54,
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(5),
+                            borderSide: const BorderSide(
+                              color: Color.fromRGBO(19, 19, 19, 1),
+                            ),
+                          ),
+                          enabledBorder: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(5),
+                            borderSide: const BorderSide(
+                              color: Color.fromRGBO(19, 19, 19, 1),
+                            ),
+                          ),
+                          fillColor: const Color.fromRGBO(44, 44, 44, 1),
+                          filled: true,
                         ),
                       ),
-                      fillColor: const Color.fromRGBO(44, 44, 44, 1),
-                      filled: true,
                     ),
                   ),
-                ),
-              ),
-              Transform.scale(
-                scale: 1.25,
-                child: Checkbox(
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  fillColor: WidgetStateProperty.resolveWith((Set states) {
-                    if (states.contains(WidgetState.selected)) {
-                      return Colors.white;
-                    }
-                    return Colors.transparent;
-                  }),
-                  side: WidgetStateBorderSide.resolveWith(
-                    (states) => const BorderSide(
-                      width: 2.0,
-                      color: Colors.white,
-                      strokeAlign: BorderSide.strokeAlignOutside,
+                  Transform.scale(
+                    scale: 1.25,
+                    child: Checkbox(
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      fillColor: WidgetStateProperty.resolveWith((Set states) {
+                        if (states.contains(WidgetState.selected)) {
+                          return Colors.white;
+                        }
+                        return Colors.transparent;
+                      }),
+                      side: WidgetStateBorderSide.resolveWith(
+                        (states) => const BorderSide(
+                          width: 2.0,
+                          color: Colors.white,
+                          strokeAlign: BorderSide.strokeAlignOutside,
+                        ),
+                      ),
+                      value: state.photosSelected.contains(widget.image),
+                      onChanged: (newValue) {
+                        context
+                            .read<CameraCubit>()
+                            .toggleImageInUploadList(widget.image);
+                      },
                     ),
                   ),
-                  value: toggle,
-                  onChanged: (newValue) {
-                    setState(() {
-                      toggle = !toggle;
-                    });
-                  },
-                ),
+                ],
               ),
+              uploadStatus != null ? const Gap(10) : const Gap(0),
+              uploadStatus != null
+                  ? LinearProgressIndicator(
+                      value: uploadStatus,
+                      backgroundColor: Colors.white,
+                    )
+                  : const Gap(0),
             ],
           ),
         );

--- a/lib/components/camera_comp/captured_image_list_comp/captured_list_fab.dart
+++ b/lib/components/camera_comp/captured_image_list_comp/captured_list_fab.dart
@@ -2,53 +2,60 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class CapturedListFab extends StatelessWidget {
-  final int count;
+  final int? count;
   final Color backgroundColor;
   final double horizontalPadding;
   final IconData icon;
   final Color contentColor;
   final double borderRadius;
+  final VoidCallback onTap;
   const CapturedListFab({
     super.key,
-    required this.count,
+    this.count,
     required this.backgroundColor,
     required this.horizontalPadding,
     required this.icon,
     required this.contentColor,
     required this.borderRadius,
+    required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 50,
-      decoration: BoxDecoration(
-        color: backgroundColor,
-        borderRadius: BorderRadius.circular(borderRadius),
-        boxShadow: const [
-          BoxShadow(
-            color: Colors.black54,
-            offset: Offset(0, 2),
-            blurRadius: 5,
-            spreadRadius: 1,
-          ),
-        ],
-      ),
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-        child: Center(
-          child: Row(
-            children: [
-              Icon(icon, color: contentColor),
-              Text(
-                count.toString(),
-                style: GoogleFonts.montserrat(
-                  color: contentColor,
-                  fontSize: 18,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        height: 50,
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(borderRadius),
+          boxShadow: const [
+            BoxShadow(
+              color: Colors.black54,
+              offset: Offset(0, 2),
+              blurRadius: 5,
+              spreadRadius: 1,
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+          child: Center(
+            child: Row(
+              children: [
+                Icon(icon, color: contentColor),
+                count != null
+                    ? Text(
+                        count.toString(),
+                        style: GoogleFonts.montserrat(
+                          color: contentColor,
+                          fontSize: 18,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      )
+                    : const SizedBox.shrink(),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/components/camera_comp/edit_screen_comp/empty_edit_view.dart
+++ b/lib/components/camera_comp/edit_screen_comp/empty_edit_view.dart
@@ -31,7 +31,7 @@ class EmptyEditView extends StatelessWidget {
           children: [
             Expanded(child: Container()),
             Text(
-              "No photos",
+              "No photos 😅",
               overflow: TextOverflow.visible,
               textAlign: TextAlign.center,
               style: GoogleFonts.josefinSans(
@@ -41,37 +41,37 @@ class EmptyEditView extends StatelessWidget {
               ),
             ),
             const Gap(50),
-            GestureDetector(
-              onTap: () async {
-                List<XFile>? selectedImages =
-                    await imagePicker.pickMultiImage();
-                addListPhotos(selectedImages);
-              },
-              child: IntrinsicWidth(
-                stepWidth: 65,
-                child: Container(
-                  height: 60,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 20,
-                  ),
-                  alignment: Alignment.center,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(10),
-                    color: const Color.fromRGBO(44, 44, 44, 1),
-                  ),
-                  child: Text(
-                    "Add from Gallery 😅",
-                    style: GoogleFonts.montserrat(
-                      color: Colors.white,
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ),
-            ),
+            // GestureDetector(
+            //   onTap: () async {
+            //     List<XFile>? selectedImages =
+            //         await imagePicker.pickMultiImage();
+            //     addListPhotos(selectedImages);
+            //   },
+            //   child: IntrinsicWidth(
+            //     stepWidth: 65,
+            //     child: Container(
+            //       height: 60,
+            //       padding: const EdgeInsets.symmetric(
+            //         horizontal: 20,
+            //       ),
+            //       alignment: Alignment.center,
+            //       decoration: BoxDecoration(
+            //         borderRadius: BorderRadius.circular(10),
+            //         color: const Color.fromRGBO(44, 44, 44, 1),
+            //       ),
+            //       child: Text(
+            //         "Add from Gallery 😅",
+            //         style: GoogleFonts.montserrat(
+            //           color: Colors.white,
+            //           fontSize: 16,
+            //           fontWeight: FontWeight.w700,
+            //         ),
+            //       ),
+            //     ),
+            //   ),
+            // ),
             const Spacer(),
-            const SubmitImageButton(),
+            // const SubmitImageButton(),
             const SizedBox(height: 35)
           ],
         ),

--- a/lib/models/captured_image.dart
+++ b/lib/models/captured_image.dart
@@ -1,20 +1,29 @@
+import 'dart:async';
+
 import 'package:camera/camera.dart';
 import 'package:shared_photo/models/photo.dart';
+import 'package:uuid/uuid.dart';
 
 class CapturedImage {
   XFile imageXFile;
+  String uuid;
   String? albumID;
   String? caption;
   bool addToRecap;
   UploadType type;
+  StreamController<double> uploadStatusController =
+      StreamController<double>.broadcast();
 
   CapturedImage({
     required this.imageXFile,
     required this.type,
+    String? uuid,
     this.albumID,
     this.addToRecap = false,
     this.caption,
-  });
+  }) : uuid = uuid ?? const Uuid().v4();
+
+  Stream<double> get uploadStatus => uploadStatusController.stream;
 
   CapturedImage setAddToRecap(bool newValue) {
     return CapturedImage(
@@ -34,6 +43,7 @@ class CapturedImage {
     }
 
     return {
+      "uuid": uuid,
       "image_xfile": imageXFile.path,
       "album_id": albumID ?? '',
       "caption": caption,
@@ -48,6 +58,7 @@ class CapturedImage {
     }
 
     return CapturedImage(
+      uuid: json['uuid'],
       imageXFile: XFile(json['image_xfile']),
       albumID: json['album_id'],
       caption: json['caption'],

--- a/lib/repositories/data_repository/album_data_repo.dart
+++ b/lib/repositories/data_repository/album_data_repo.dart
@@ -101,7 +101,11 @@ extension AlbumDataRepo on DataRepository {
     }
 
     (success, error) = await ImageService.uploadPhoto(
-        user.token, albumCoverPath, album.albumCoverId);
+      user.token,
+      albumCoverPath,
+      album.albumCoverId,
+      StreamController<double>.broadcast(),
+    );
     if (success == false) {
       return (false, error);
     }

--- a/lib/screens/captured_image_list_screen.dart
+++ b/lib/screens/captured_image_list_screen.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:shared_photo/components/camera_comp/captured_image_list_comp/captured_image_item.dart';
 import 'package:shared_photo/components/camera_comp/captured_image_list_comp/captured_list_fab.dart';
 import 'package:shared_photo/components/camera_comp/edit_album_dropdown.dart';
+import 'package:shared_photo/components/camera_comp/edit_screen_comp/empty_edit_view.dart';
+import 'package:shared_photo/models/photo.dart';
 
 import '../bloc/cubit/camera_cubit.dart';
 
@@ -13,8 +16,20 @@ class CapturedImageListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ImagePicker imagePicker = ImagePicker();
+
+    void addListPhotos(List<XFile>? selectedImages) {
+      if (selectedImages == null) return;
+
+      context
+          .read<CameraCubit>()
+          .addListOfPhotosToList(selectedImages, UploadType.forgotShot);
+    }
+
     return BlocBuilder<CameraCubit, CameraState>(
       builder: (context, state) {
+        bool itemsSelected = state.selectedAlbumSelectedImageList.isNotEmpty;
+
         return SafeArea(
           child: Scaffold(
             resizeToAvoidBottomInset: true,
@@ -38,46 +53,88 @@ class CapturedImageListScreen extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 10),
               child: Stack(
                 children: [
-                  ListView.builder(
-                    itemCount: state.selectedAlbumImageList.length,
-                    itemBuilder: (context, item) => CapturedImageItem(
-                      imagePath:
-                          state.selectedAlbumImageList[item].imageXFile.path,
-                    ),
-                  ),
+                  state.selectedAlbumImageList.isNotEmpty
+                      ? ListView.builder(
+                          itemCount: state.selectedAlbumImageList.length,
+                          itemBuilder: (context, item) => CapturedImageItem(
+                            key: ValueKey(
+                                state.selectedAlbumImageList[item].hashCode),
+                            image: state.selectedAlbumImageList[item],
+                          ),
+                        )
+                      : const EmptyEditView(),
                   Positioned(
                     bottom: 40,
                     width: MediaQuery.of(context).size.width - 20,
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        const CapturedListFab(
-                          count: 0,
-                          backgroundColor: Color.fromRGBO(19, 19, 19, 1),
-                          horizontalPadding: 15,
-                          icon: Icons.delete_forever,
-                          contentColor: Colors.white54,
-                          borderRadius: 5,
-                        ),
-                        const Gap(7),
-                        const CapturedListFab(
-                          count: 0,
-                          backgroundColor: Color.fromRGBO(136, 98, 106, 1),
-                          horizontalPadding: 15,
-                          icon: Icons.upload_rounded,
-                          contentColor: Colors.white54,
-                          borderRadius: 5,
-                        ),
+                        itemsSelected
+                            ? CapturedListFab(
+                                count:
+                                    state.selectedAlbumSelectedImageList.length,
+                                backgroundColor:
+                                    const Color.fromRGBO(19, 19, 19, 1),
+                                horizontalPadding: 15,
+                                icon: Icons.delete_forever,
+                                contentColor: Colors.white54,
+                                borderRadius: 5,
+                                onTap: () => context
+                                    .read<CameraCubit>()
+                                    .removeImageFromUploadList(),
+                              )
+                            : const SizedBox.shrink(),
+                        (itemsSelected &&
+                                state.selectedAlbumSelectedImageList.length !=
+                                    state.selectedAlbumImageList.length)
+                            ? const Gap(7)
+                            : const Gap(0),
+                        (itemsSelected &&
+                                state.selectedAlbumSelectedImageList.length !=
+                                    state.selectedAlbumImageList.length)
+                            ? CapturedListFab(
+                                count:
+                                    state.selectedAlbumSelectedImageList.length,
+                                backgroundColor:
+                                    const Color.fromRGBO(136, 98, 106, 1),
+                                horizontalPadding: 15,
+                                icon: Icons.upload_rounded,
+                                contentColor: Colors.white.withOpacity(.75),
+                                borderRadius: 5,
+                                onTap: () => context
+                                    .read<CameraCubit>()
+                                    .uploadSelectedPhotos(),
+                              )
+                            : const SizedBox.shrink(),
+                        itemsSelected ? const Gap(7) : const Gap(0),
+                        state.selectedAlbumImageList.isNotEmpty
+                            ? CapturedListFab(
+                                count: state.selectedAlbumImageList.length,
+                                backgroundColor:
+                                    const Color.fromRGBO(181, 131, 141, 1),
+                                horizontalPadding: 25,
+                                icon: Icons.upload_rounded,
+                                contentColor: Colors.white,
+                                borderRadius: 5,
+                                onTap: () => context
+                                    .read<CameraCubit>()
+                                    .uploadAllImagesToAlbum(),
+                              )
+                            : const SizedBox.shrink(),
                         const Gap(7),
                         CapturedListFab(
-                          count: state.selectedAlbumImageList.length,
-                          backgroundColor:
-                              const Color.fromRGBO(181, 131, 141, 1),
-                          horizontalPadding: 25,
-                          icon: Icons.upload_rounded,
+                          backgroundColor: const Color.fromRGBO(44, 44, 44, 1),
+                          horizontalPadding: 15,
+                          icon: Icons.add_photo_alternate_rounded,
                           contentColor: Colors.white,
                           borderRadius: 5,
-                        ),
+                          onTap: () async {
+                            List<XFile>? selectedImages =
+                                await imagePicker.pickMultiImage();
+
+                            addListPhotos(selectedImages);
+                          },
+                        )
                       ],
                     ),
                   ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -838,7 +838,7 @@ packages:
     source: hosted
     version: "1.3.2"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "83d37c7ad7aaf9aa8e275490669535c8080377cfa7a7004c24dfac53afffaa90"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   path_provider: ^2.1.3
   animated_toggle_switch: ^0.8.2
   dio: ^5.5.0+1
+  uuid: ^4.4.2
 
 dev_dependencies:
   flutter_lints: ^2.0.0


### PR DESCRIPTION
Implemented the necessary functionality to upload a single image to an album, this also included the work necessary to upload many individual images to an album. This updates are done on an album basis - so uploading images to an album will only be done on the selected album. Also updated the image capture page to have an empty view. Implemented streams to communicate from the image service to the UI in order to add loading statuses. Also updated the gallery add so that it pushes to the uploaded page after selecting images.