### PR TITLE
las-368-new-upload-logic

### DIFF
--- a/lib/bloc/cubit/camera_state.dart
+++ b/lib/bloc/cubit/camera_state.dart
@@ -5,6 +5,7 @@ enum UploadMode { unlockedAlbums, singleAlbum }
 class CameraState extends Equatable {
   final List<CapturedImage> photosTaken;
   final List<CapturedImage> photosSelected;
+  final Map<String, CapturedImage> failedUploads;
   final int? selectedIndex;
   final CapturedImage? selectedImage;
   final Map<String, Album> albumMap;
@@ -16,6 +17,7 @@ class CameraState extends Equatable {
   const CameraState({
     required this.photosTaken,
     required this.photosSelected,
+    required this.failedUploads,
     required this.selectedIndex,
     required this.selectedImage,
     required this.albumMap,
@@ -30,6 +32,7 @@ class CameraState extends Equatable {
     return CameraState(
       photosTaken: const [],
       photosSelected: const [],
+      failedUploads: const {},
       selectedIndex: null,
       selectedImage: null,
       selectedAlbum: null,
@@ -43,6 +46,7 @@ class CameraState extends Equatable {
   CameraState copyWith({
     List<CapturedImage>? photosTaken,
     List<CapturedImage>? photosSelected,
+    Map<String, CapturedImage>? failedUploads,
     int? selectedIndex,
     CapturedImage? selectedImage,
     Map<String, Album>? albumMap,
@@ -55,6 +59,7 @@ class CameraState extends Equatable {
     return CameraState(
       photosTaken: photosTaken ?? this.photosTaken,
       photosSelected: photosSelected ?? this.photosSelected,
+      failedUploads: failedUploads ?? this.failedUploads,
       selectedIndex: selectedIndex ?? this.selectedIndex,
       selectedImage: selectedImage ?? this.selectedImage,
       selectedAlbum: selectedAlbum ?? this.selectedAlbum,
@@ -113,6 +118,7 @@ class CameraState extends Equatable {
   List<Object?> get props => [
         photosTaken,
         photosSelected,
+        failedUploads,
         selectedIndex,
         selectedAlbum,
         albumMap,

--- a/lib/components/camera_comp/camera_utils/camera_controls.dart
+++ b/lib/components/camera_comp/camera_utils/camera_controls.dart
@@ -4,7 +4,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:shared_photo/bloc/cubit/camera_cubit.dart';
 import 'package:shared_photo/components/camera_comp/camera_utils/shutter_button.dart';
-import 'package:shared_photo/components/camera_comp/edit_screen_comp/captured_edit_screen.dart';
 import 'package:shared_photo/models/photo.dart';
 import 'package:shared_photo/screens/captured_image_list_screen.dart';
 

--- a/lib/components/camera_comp/captured_image_list_comp/captured_image_item.dart
+++ b/lib/components/camera_comp/captured_image_list_comp/captured_image_item.dart
@@ -28,8 +28,6 @@ class _CapturedImageItemState extends State<CapturedImageItem> {
     super.initState();
 
     subscription = widget.image.uploadStatusController.stream.listen((onData) {
-      print("${onData} from item");
-
       setState(() {
         uploadStatus = onData;
       });
@@ -159,7 +157,10 @@ class _CapturedImageItemState extends State<CapturedImageItem> {
               uploadStatus != null
                   ? LinearProgressIndicator(
                       value: uploadStatus,
-                      backgroundColor: Colors.white,
+                      backgroundColor: Colors.transparent,
+                      valueColor: const AlwaysStoppedAnimation<Color>(
+                        Color.fromRGBO(181, 131, 141, 1),
+                      ),
                     )
                   : const Gap(0),
             ],

--- a/lib/components/camera_comp/captured_preview_listview.dart
+++ b/lib/components/camera_comp/captured_preview_listview.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_photo/bloc/cubit/camera_cubit.dart';
-import 'package:shared_photo/components/camera_comp/edit_screen_comp/captured_edit_screen.dart';
 import 'package:shared_photo/screens/captured_image_list_screen.dart';
 
 class CapturedPreviewListView extends StatelessWidget {

--- a/lib/components/camera_comp/edit_screen_comp/empty_edit_view.dart
+++ b/lib/components/camera_comp/edit_screen_comp/empty_edit_view.dart
@@ -1,26 +1,25 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
+// import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:image_picker/image_picker.dart';
-import 'package:shared_photo/bloc/cubit/camera_cubit.dart';
-import 'package:shared_photo/components/camera_comp/edit_screen_comp/submit_image_button.dart';
-import 'package:shared_photo/models/photo.dart';
+// import 'package:image_picker/image_picker.dart';
+// import 'package:shared_photo/bloc/cubit/camera_cubit.dart';
+// import 'package:shared_photo/models/photo.dart';
 
 class EmptyEditView extends StatelessWidget {
   const EmptyEditView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final ImagePicker imagePicker = ImagePicker();
+    //final ImagePicker imagePicker = ImagePicker();
 
-    void addListPhotos(List<XFile>? selectedImages) {
-      if (selectedImages == null) return;
+    // void addListPhotos(List<XFile>? selectedImages) {
+    //   if (selectedImages == null) return;
 
-      context
-          .read<CameraCubit>()
-          .addListOfPhotosToList(selectedImages, UploadType.forgotShot);
-    }
+    //   context
+    //       .read<CameraCubit>()
+    //       .addListOfPhotosToList(selectedImages, UploadType.forgotShot);
+    // }
 
     return SafeArea(
       child: Padding(

--- a/lib/models/captured_image.dart
+++ b/lib/models/captured_image.dart
@@ -74,6 +74,7 @@ class CapturedImage {
     }
 
     return {
+      "uuid": uuid,
       "album_id": albumID ?? '',
       "caption": caption,
       "upload_type": typeString,

--- a/lib/screens/captured_image_list_screen.dart
+++ b/lib/screens/captured_image_list_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:shared_photo/components/camera_comp/captured_image_list_comp/captured_image_item.dart';
 import 'package:shared_photo/components/camera_comp/captured_image_list_comp/captured_list_fab.dart';

--- a/lib/services/image_service.dart
+++ b/lib/services/image_service.dart
@@ -121,7 +121,6 @@ class ImageService {
     Uint8List imageBytes = await File(imagePath).readAsBytes();
 
     if (statusController.isClosed) {
-      print('controller is closed');
       return (false, "controller is closed");
     }
 
@@ -146,7 +145,6 @@ class ImageService {
           // },
           onSendProgress: (int sent, int total) {
             double statusPercent = sent / total;
-            print(statusPercent);
             if (statusController.isClosed == false) {
               statusController.add(statusPercent);
             }
@@ -155,12 +153,6 @@ class ImageService {
 
         developer.log("upload finished");
 
-        // final uploadResponse = await http.post(
-        //   gcpSignedUrl,
-        //   headers: gcpHeader,
-        //   body: imageBytes,
-        // );
-
         if (uploadResponse.statusCode == 200) {
           return (true, null);
         }
@@ -168,7 +160,6 @@ class ImageService {
       }
       String code = response.statusCode.toString();
       String body = response.body;
-      //developer.log("$code: $body");
 
       return (false, "$code: $body");
     } catch (e) {
@@ -217,7 +208,7 @@ class ImageService {
     }
   }
 
-  static Future<(Photo?, String?)> postCapturedImage(
+  static Future<(Photo?, String?)> postCapturedImageData(
     String token,
     CapturedImage image,
   ) async {
@@ -239,18 +230,6 @@ class ImageService {
       if (response.statusCode == 200) {
         Map<String, dynamic> body = json.decode(response.body);
         Photo newImage = Photo.fromMap(body);
-
-        bool upload;
-        String? error;
-        (upload, error) = await uploadPhoto(
-          token,
-          image.imageXFile.path,
-          newImage.imageId,
-          image.uploadStatusController,
-        );
-        if (upload == false) {
-          return (null, error);
-        }
 
         return (newImage, null);
       } else {


### PR DESCRIPTION
Decoupled the logic in the image service file so that the image upload is a single function and the data upload is a separate function. This allows me to handle the individual functions within the repository layer when these functions are called. I then manage any failed image data calls within the cubit where I maintain the image if the image upload fails and if the data fails then it is saved to a local store until signal is available. This runs upon start up and has an exponential backoff that it uses to retry. This is paired with server side changes to handle being passed a UUID.