### PR TITLE
las-376-update-camera-capture-aspect-ratio-to-persist

### DIFF
--- a/lib/components/camera_comp/camera_utils/camera_controls.dart
+++ b/lib/components/camera_comp/camera_utils/camera_controls.dart
@@ -95,9 +95,13 @@ class _CameraControlsState extends State<CameraControls> {
         ),
         GestureDetector(
           onTap: () async {
-            List<XFile>? selectedImages = await imagePicker
-                .pickMultiImage()
-                .whenComplete(() => pushCapturedPage());
+            List<XFile>? selectedImages;
+            selectedImages =
+                await imagePicker.pickMultiImage().whenComplete(() {
+              if (selectedImages != null) {
+                pushCapturedPage();
+              }
+            });
             addListPhotos(selectedImages);
           },
           child: const Icon(

--- a/lib/components/camera_comp/camera_utils/shutter_button.dart
+++ b/lib/components/camera_comp/camera_utils/shutter_button.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:camera/camera.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -10,10 +11,30 @@ import 'package:shared_photo/models/album.dart';
 import 'package:shared_photo/models/captured_image.dart';
 import 'package:shared_photo/models/photo.dart';
 
-class ShutterButton extends StatelessWidget {
+class ShutterButton extends StatefulWidget {
   final CameraController controller;
 
   const ShutterButton({super.key, required this.controller});
+
+  @override
+  State<ShutterButton> createState() => _ShutterButtonState();
+}
+
+class _ShutterButtonState extends State<ShutterButton> {
+  double shutterSize = 75;
+  double scale = 1;
+
+  void shutterPressDown(TapDownDetails details) {
+    setState(() {
+      scale = 0.65;
+    });
+  }
+
+  void animationEnd() {
+    setState(() {
+      scale = 1;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -38,46 +59,60 @@ class ShutterButton extends StatelessWidget {
 
         return Padding(
           padding: const EdgeInsets.symmetric(
-            horizontal: 15.0,
-            vertical: 15,
+            horizontal: 20.0,
+            vertical: 20,
           ),
-          child: InkWell(
+          child: GestureDetector(
             onTap: selectedAlbum != null
                 ? () async {
-                    HapticFeedback.heavyImpact();
-                    XFile picture = await controller.takePicture();
+                    HapticFeedback.selectionClick();
+                    XFile picture = await widget.controller.takePicture();
 
                     addPhotoToCubit(picture);
                   }
                 : null,
+            onTapDown: shutterPressDown,
             child: Container(
-              width: 85,
-              height: 85,
-              clipBehavior: Clip.hardEdge,
-              decoration: BoxDecoration(
-                color: Colors.white.withOpacity(.5),
-                borderRadius: BorderRadius.circular(85),
-                border: Border.all(
-                  color: Colors.black,
-                  width: 5,
-                  strokeAlign: BorderSide.strokeAlignOutside,
-                ),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.25),
-                    offset: const Offset(0, 4),
-                    blurRadius: 10,
-                    spreadRadius: 1,
+                width: shutterSize,
+                height: shutterSize,
+                clipBehavior: Clip.hardEdge,
+                decoration: BoxDecoration(
+                  //color: Colors.white.withOpacity(.5),
+                  borderRadius: BorderRadius.circular(shutterSize),
+                  border: Border.all(
+                    color: Colors.white,
+                    width: 5,
+                    strokeAlign: BorderSide.strokeAlignOutside,
                   ),
-                ],
-              ),
-              child: ClipOval(
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
-                  child: Container(),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.25),
+                      offset: const Offset(0, 4),
+                      blurRadius: 10,
+                      spreadRadius: 1,
+                    ),
+                  ],
                 ),
-              ),
-            ),
+                child: AnimatedScale(
+                  scale: scale,
+                  duration: const Duration(milliseconds: 110),
+                  curve: Curves.easeIn,
+                  onEnd: animationEnd,
+                  child: Container(
+                    width: shutterSize,
+                    height: shutterSize,
+                    margin: const EdgeInsets.all(5),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(shutterSize),
+                      // border: Border.all(
+                      //   color: Colors.white54,
+                      //   width: 8,
+                      //   strokeAlign: BorderSide.strokeAlignOutside,
+                      // ),
+                    ),
+                  ),
+                )),
           ),
         );
       },

--- a/lib/components/camera_comp/custom_cam_preview.dart
+++ b/lib/components/camera_comp/custom_cam_preview.dart
@@ -33,13 +33,12 @@ class _CustomCamPreviewState extends State<CustomCamPreview> {
   void pinchUpdate(ScaleUpdateDetails details) async {
     double newScale = 0;
     double newZoom = 0;
-    print(details.scale);
 
     if (details.scale == 1) return;
 
     newScale = details.scale - previousScale;
     if (newScale < 1) {
-      newScale = newScale * 5;
+      newScale = newScale * 6;
     }
     newZoom = currentZoom + newScale;
 
@@ -63,7 +62,7 @@ class _CustomCamPreviewState extends State<CustomCamPreview> {
   Widget build(BuildContext context) {
     //final size = MediaQuery.of(context).size;
     return AspectRatio(
-      aspectRatio: 9 / 16,
+      aspectRatio: 1 / widget.controller.value.aspectRatio,
       child: Container(
         //width: size.width,
         //height: size.height,
@@ -79,13 +78,7 @@ class _CustomCamPreviewState extends State<CustomCamPreview> {
         child: GestureDetector(
           onScaleEnd: pinchEnd,
           onScaleUpdate: pinchUpdate,
-          child: FittedBox(
-            fit: BoxFit.fitHeight,
-            child: SizedBox(
-              width: 100,
-              child: CameraPreview(widget.controller),
-            ),
-          ),
+          child: CameraPreview(widget.controller),
         ),
       ),
     );

--- a/lib/components/new_app_frame/new_bottom_app_bar.dart
+++ b/lib/components/new_app_frame/new_bottom_app_bar.dart
@@ -17,6 +17,7 @@ class NewBottomAppBar extends StatelessWidget {
           context.read<NotificationCubit>().clearTempNotifications();
         }
         return BottomAppBar(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
           height: 85,
           surfaceTintColor: Colors.transparent,
           color: Colors.transparent,

--- a/lib/screens/camera.dart
+++ b/lib/screens/camera.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:camera/camera.dart';
 import 'package:flutter/services.dart';
@@ -40,7 +38,7 @@ class _CameraScreenState extends State<CameraScreen> {
           );
     controller = CameraController(
       camera,
-      ResolutionPreset.max,
+      ResolutionPreset.ultraHigh,
       imageFormatGroup: ImageFormatGroup.yuv420,
     );
 
@@ -94,7 +92,7 @@ class _CameraScreenState extends State<CameraScreen> {
 
     controller = CameraController(
       widget.cameras[cameraSelect],
-      ResolutionPreset.high,
+      ResolutionPreset.ultraHigh,
       imageFormatGroup: ImageFormatGroup.yuv420,
     );
 
@@ -115,11 +113,13 @@ class _CameraScreenState extends State<CameraScreen> {
         return Stack(
           children: [
             (controller.value.isInitialized)
-                ? Padding(
-                    padding: EdgeInsets.only(
-                        top: MediaQuery.of(context).viewPadding.top),
+                ? SizedBox(
+                    height: size.height,
                     child: Column(
                       children: [
+                        SizedBox(
+                          height: MediaQuery.of(context).viewPadding.top,
+                        ),
                         Expanded(
                           child: GestureDetector(
                             onDoubleTap: () => changeCameraDirection(),
@@ -130,9 +130,7 @@ class _CameraScreenState extends State<CameraScreen> {
                             ),
                           ),
                         ),
-                        const SizedBox(
-                          height: kBottomNavigationBarHeight + 90 / 2,
-                        ),
+                        const SizedBox(height: 110),
                       ],
                     ),
                   )
@@ -153,13 +151,13 @@ class _CameraScreenState extends State<CameraScreen> {
               ),
             ),
             Positioned(
-              bottom: 125, //MediaQuery.of(context).size.height * .75,
+              bottom: 110 + 25, //MediaQuery.of(context).size.height * .75,
               left: MediaQuery.of(context).size.width * .75,
               right: 0,
               child: const CameraImageStack(),
             ),
             Positioned(
-                bottom: 125, //MediaQuery.of(context).size.height * .75,
+                bottom: 110 + 25, //MediaQuery.of(context).size.height * .75,
                 left: 0,
                 right: 0,
                 child: CameraControls(


### PR DESCRIPTION
Adjusted the camera page so that the view insets are safe and the bottom navigation bar doesn't cover up the camera preview. Also added an animation so when you press the shutter button it scales to confirm the picture is being taken. Also fixed the gallery selector to not open the edit page if no image is selected from the gallery.