### PR TITLE
las-385-image-view-zoom

### DIFF
--- a/lib/components/album_comp/image_components/blank_item_component.dart
+++ b/lib/components/album_comp/image_components/blank_item_component.dart
@@ -9,12 +9,12 @@ import 'package:shared_photo/repositories/data_repository/data_repository.dart';
 import 'package:shared_photo/screens/image_frame.dart';
 
 class BlankItemComponent extends StatelessWidget {
-  final String url;
+  final String avatarUrl;
   final Map<String, String> headers;
   final Photo image;
   const BlankItemComponent({
     super.key,
-    required this.url,
+    required this.avatarUrl,
     required this.headers,
     required this.image,
   });
@@ -42,6 +42,7 @@ class BlankItemComponent extends StatelessWidget {
                 isScrollControlled: true,
                 useRootNavigator: true,
                 useSafeArea: true,
+                enableDrag: false,
                 builder: (ctx) => MultiBlocProvider(
                   providers: [
                     BlocProvider(
@@ -82,7 +83,7 @@ class BlankItemComponent extends StatelessWidget {
                 child: CircleAvatar(
                   backgroundColor: const Color.fromRGBO(16, 16, 16, 1),
                   foregroundImage: CachedNetworkImageProvider(
-                    url,
+                    avatarUrl,
                     headers: headers,
                   ),
                   radius: 10,

--- a/lib/components/album_comp/image_components/first_item_component.dart
+++ b/lib/components/album_comp/image_components/first_item_component.dart
@@ -34,6 +34,7 @@ class FirstItemComponent extends StatelessWidget {
           isScrollControlled: true,
           useRootNavigator: true,
           useSafeArea: true,
+          enableDrag: false,
           builder: (ctx) => MultiBlocProvider(
             providers: [
               BlocProvider(

--- a/lib/components/album_comp/image_components/guest_item_component.dart
+++ b/lib/components/album_comp/image_components/guest_item_component.dart
@@ -37,6 +37,7 @@ class GuestItemComponent extends StatelessWidget {
           isScrollControlled: true,
           useRootNavigator: true,
           useSafeArea: true,
+          enableDrag: false,
           builder: (ctx) => MultiBlocProvider(
             providers: [
               BlocProvider(

--- a/lib/components/album_comp/image_components/top_item_component.dart
+++ b/lib/components/album_comp/image_components/top_item_component.dart
@@ -42,6 +42,7 @@ class TopItemComponent extends StatelessWidget {
                 isScrollControlled: true,
                 useRootNavigator: true,
                 useSafeArea: true,
+                isDismissible: false,
                 builder: (ctx) => MultiBlocProvider(
                   providers: [
                     BlocProvider(

--- a/lib/components/album_comp/lock_comps/lock_timeline_page.dart
+++ b/lib/components/album_comp/lock_comps/lock_timeline_page.dart
@@ -53,7 +53,8 @@ class LockTimelinePage extends StatelessWidget {
                         } else {
                           return BlankItemComponent(
                             image: album.imagesGroupedSortedByDate[index][item],
-                            url: album.imagesGroupedSortedByDate[index][item]
+                            avatarUrl: album
+                                .imagesGroupedSortedByDate[index][item]
                                 .avatarReq,
                             headers: header,
                           );

--- a/lib/components/album_comp/reveal_comps/album_reveal_tab_view.dart
+++ b/lib/components/album_comp/reveal_comps/album_reveal_tab_view.dart
@@ -37,6 +37,7 @@ class AlbumRevealTabView extends StatelessWidget {
               isScrollControlled: true,
               useRootNavigator: true,
               useSafeArea: true,
+              enableDrag: false,
               builder: (ctx) => MultiBlocProvider(
                 providers: [
                   BlocProvider(

--- a/lib/components/album_comp/unlock_comps/unlock_timeline_page.dart
+++ b/lib/components/album_comp/unlock_comps/unlock_timeline_page.dart
@@ -61,8 +61,9 @@ class UnlockTimelinePage extends StatelessWidget {
                             child: BlankItemComponent(
                               image: album.imagesGroupedSortedByDate[index]
                                   [item],
-                              url: album.imagesGroupedSortedByDate[index][item]
-                                  .imageReqSmallSize,
+                              avatarUrl: album
+                                  .imagesGroupedSortedByDate[index][item]
+                                  .avatarReq,
                               headers: header,
                             ),
                           );

--- a/lib/components/image_page_comp/image_frame_container/image_frame_image_container.dart
+++ b/lib/components/image_page_comp/image_frame_container/image_frame_image_container.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:icon_decoration/icon_decoration.dart';
+import 'package:pinch_zoom_release_unzoom/pinch_zoom_release_unzoom.dart';
 import 'package:shared_photo/bloc/bloc/app_bloc.dart';
 import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
 import 'package:shared_photo/bloc/cubit/image_frame_cubit.dart';
@@ -14,9 +15,16 @@ import 'package:shared_photo/components/image_page_comp/image_frame_dialog/more_
 import 'package:shared_photo/models/album.dart';
 import 'dart:math' as math;
 
-class ImageFrameImageContainer extends StatelessWidget {
+class ImageFrameImageContainer extends StatefulWidget {
   const ImageFrameImageContainer({super.key});
 
+  @override
+  State<ImageFrameImageContainer> createState() =>
+      _ImageFrameImageContainerState();
+}
+
+class _ImageFrameImageContainerState extends State<ImageFrameImageContainer> {
+  bool canScroll = true;
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
@@ -27,6 +35,9 @@ class ImageFrameImageContainer extends StatelessWidget {
           children: [
             PageView.builder(
               controller: state.pageController,
+              physics: canScroll
+                  ? AlwaysScrollableScrollPhysics()
+                  : NeverScrollableScrollPhysics(),
               onPageChanged: (index) {
                 context
                     .read<AlbumFrameCubit>()
@@ -51,17 +62,26 @@ class ImageFrameImageContainer extends StatelessWidget {
                 if (showImage) {
                   return Stack(
                     children: [
-                      Container(
-                        decoration: BoxDecoration(
-                          color: const Color.fromRGBO(19, 19, 19, 1),
-                          image: DecorationImage(
-                            image: CachedNetworkImageProvider(
-                              state.imageFrameTimelineList[index].imageReq,
-                              headers: headers,
+                      PinchZoomReleaseUnzoomWidget(
+                        twoFingersOn: () => setState(() {
+                          canScroll = false;
+                        }),
+                        twoFingersOff: () => setState(() {
+                          canScroll = true;
+                        }),
+                        resetDuration: Duration(milliseconds: 300),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: const Color.fromRGBO(19, 19, 19, 1),
+                            image: DecorationImage(
+                              image: CachedNetworkImageProvider(
+                                state.imageFrameTimelineList[index].imageReq,
+                                headers: headers,
+                              ),
+                              fit: BoxFit.fitWidth,
                             ),
-                            fit: BoxFit.fitWidth,
+                            borderRadius: BorderRadius.circular(10),
                           ),
-                          borderRadius: BorderRadius.circular(10),
                         ),
                       ),
                       BlocBuilder<ImageFrameCubit, ImageFrameState>(

--- a/lib/components/image_page_comp/image_frame_container/zoomable_image.dart
+++ b/lib/components/image_page_comp/image_frame_container/zoomable_image.dart
@@ -1,0 +1,39 @@
+import 'dart:ffi';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+class ZoomableImage extends StatefulWidget {
+  final String imageUrl;
+  final Map<String, String> headers;
+  const ZoomableImage({
+    super.key,
+    required this.imageUrl,
+    required this.headers,
+  });
+
+  @override
+  State<ZoomableImage> createState() => _ZoomableImageState();
+}
+
+class _ZoomableImageState extends State<ZoomableImage> {
+  @override
+  Widget build(BuildContext context) {
+    return InteractiveViewer(
+      clipBehavior: Clip.none,
+      child: Container(
+        decoration: BoxDecoration(
+          color: const Color.fromRGBO(19, 19, 19, 1),
+          image: DecorationImage(
+            image: CachedNetworkImageProvider(
+              widget.imageUrl,
+              headers: widget.headers,
+            ),
+            fit: BoxFit.fitWidth,
+          ),
+          borderRadius: BorderRadius.circular(10),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/album_frame.dart
+++ b/lib/screens/album_frame.dart
@@ -92,6 +92,7 @@ void pushImageFrameIfPassed(BuildContext context, Arguments arguments) {
       isScrollControlled: true,
       useRootNavigator: true,
       useSafeArea: true,
+      enableDrag: false,
       builder: (ctx) => MultiBlocProvider(
         providers: [
           BlocProvider.value(

--- a/lib/screens/image_frame.dart
+++ b/lib/screens/image_frame.dart
@@ -42,6 +42,7 @@ class ImageFrame extends StatelessWidget {
                     return Container(
                       height: MediaQuery.of(context).size.height * .08,
                       margin: const EdgeInsets.only(top: 15, bottom: 15),
+                      color: Colors.transparent,
                       child: Stack(
                         children: [
                           PageView.builder(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -736,6 +736,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  pinch_zoom_release_unzoom:
+    dependency: "direct main"
+    description:
+      name: pinch_zoom_release_unzoom
+      sha256: "77ae7a6844923211cb7dca9f86e3b6333e0d75d0c44cb2d908d893725954d8cf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   dotted_border: ^2.1.0
   flutter_datetime_picker_plus: ^2.2.0
   omni_datetime_picker: ^2.0.5
+  pinch_zoom_release_unzoom: ^1.0.3
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
Added the ability to zoom in and pan images on the image frame page - utilizing a package that was then further customized within the local code base. Also update the unlock timeline view so that it shows the users avatar and not the image itself in the small circle avatar.