### PR TITLE
las-389-fetching-imagesevent-from-server-datetime-improvements

### DIFF
--- a/lib/bloc/cubit/album_frame_state.dart
+++ b/lib/bloc/cubit/album_frame_state.dart
@@ -109,8 +109,12 @@ class AlbumFrameState extends Equatable {
   List<List<Photo>> get imagesGroupedSortedByDate {
     Map<String, List<Photo>> mapImages = {};
     List<List<Photo>> listImages = [];
+    List<Photo> dateSortedImages = images;
 
-    for (var item in images) {
+    dateSortedImages
+        .sort((a, b) => a.uploadDateTime.compareTo(b.uploadDateTime));
+
+    for (var item in dateSortedImages) {
       if (!mapImages.containsKey(item.dateString)) {
         mapImages[item.dateString] = [];
       }

--- a/lib/models/photo.dart
+++ b/lib/models/photo.dart
@@ -71,7 +71,7 @@ class Photo {
       firstName: map['first_name'],
       lastName: map['last_name'],
       imageCaption: caption,
-      uploadDateTime: DateTime.parse(map['created_at']),
+      uploadDateTime: DateTime.parse(map['created_at']).toLocal(),
       likes: map['likes'],
       upvotes: map['upvotes'],
       userLiked: map['user_liked'],


### PR DESCRIPTION
Updated the app so that all the times in the devices local timezone. Also fixed the issue that was occuring with the timeline being out of order - the outer map of the timeline was not being sorted first.

closes las-386-fix-timeline-page-order