### PR TITLE
las-319-update-timeline-sections-for-forgot-shots

### DIFF
--- a/lib/bloc/cubit/album_frame_state.dart
+++ b/lib/bloc/cubit/album_frame_state.dart
@@ -110,6 +110,12 @@ class AlbumFrameState extends Equatable {
     Map<String, List<Photo>> mapImages = {};
     List<List<Photo>> listImages = [];
     List<Photo> dateSortedImages = images;
+    List<Photo> forgotImages = images;
+
+    dateSortedImages.removeWhere((test) => test.type == UploadType.forgotShot);
+    forgotImages.removeWhere((test) => test.type == UploadType.snap);
+
+    forgotImages.sort((a, b) => a.uploadDateTime.compareTo(b.uploadDateTime));
 
     dateSortedImages
         .sort((a, b) => a.uploadDateTime.compareTo(b.uploadDateTime));
@@ -130,6 +136,8 @@ class AlbumFrameState extends Equatable {
     mapImages.forEach((key, value) {
       listImages.add(value);
     });
+
+    listImages.add(forgotImages);
 
     return listImages;
   }

--- a/lib/components/album_comp/image_components/top_item_component.dart
+++ b/lib/components/album_comp/image_components/top_item_component.dart
@@ -28,8 +28,8 @@ class TopItemComponent extends StatelessWidget {
         .state
         .imageFrameTimelineList
         .indexOf(image);
-    return AspectRatio(
-      aspectRatio: 4 / 5,
+    return SizedBox(
+      height: 200,
       child: Stack(
         children: [
           GestureDetector(

--- a/lib/components/album_comp/reveal_comps/reveal_timeline_page.dart
+++ b/lib/components/album_comp/reveal_comps/reveal_timeline_page.dart
@@ -4,6 +4,7 @@ import 'package:shared_photo/bloc/bloc/app_bloc.dart';
 import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
 import 'package:shared_photo/components/album_comp/image_components/top_item_component.dart';
 import 'package:shared_photo/components/app_comp/section_header_small.dart';
+import 'package:shared_photo/models/photo.dart';
 
 class RevealTimelinePage extends StatelessWidget {
   const RevealTimelinePage({super.key});
@@ -21,34 +22,56 @@ class RevealTimelinePage extends StatelessWidget {
                 return SliverList.separated(
                   itemCount: state.imagesGroupedSortedByDate.length,
                   itemBuilder: (context, index) {
+                    int rowCount =
+                        (state.imagesGroupedSortedByDate[index].length / 3)
+                            .ceil();
+                    final double screenWidth =
+                        MediaQuery.of(context).size.width - 30;
+                    final double gridWidth = screenWidth / 3;
+                    final double desiredRowHeight = 150;
+
+                    String sectionString =
+                        state.imagesGroupedSortedByDate[index][0].dateString;
+
+                    if (state.imagesGroupedSortedByDate[index][0].type ==
+                        UploadType.forgotShot) {
+                      sectionString = "Forgot Shots 🫣";
+                    }
+
                     return Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
                           padding: const EdgeInsets.symmetric(vertical: 12.0),
-                          child: SectionHeaderSmall(state
-                              .imagesGroupedSortedByDate[index][0].dateString),
+                          child: SectionHeaderSmall(sectionString),
                         ),
-                        GridView.builder(
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          itemCount:
-                              state.imagesGroupedSortedByDate[index].length,
-                          gridDelegate:
-                              const SliverGridDelegateWithFixedCrossAxisCount(
-                            crossAxisCount: 3,
-                            mainAxisSpacing: 8,
-                            crossAxisSpacing: 8,
-                            childAspectRatio: 4 / 5,
+                        ConstrainedBox(
+                          constraints: BoxConstraints(
+                            maxHeight: 150 * rowCount.toDouble(),
                           ),
-                          itemBuilder: (context, item) {
-                            return TopItemComponent(
-                              image: state.imagesGroupedSortedByDate[index]
-                                  [item],
-                              headers: header,
-                              showCount: false,
-                            );
-                          },
+                          child: GridView.builder(
+                            //shrinkWrap: true,
+                            physics: const NeverScrollableScrollPhysics(),
+                            itemCount:
+                                state.imagesGroupedSortedByDate[index].length,
+                            gridDelegate:
+                                SliverGridDelegateWithFixedCrossAxisCount(
+                              crossAxisCount: 3,
+                              mainAxisSpacing: 8,
+                              crossAxisSpacing: 8,
+                              childAspectRatio: gridWidth / desiredRowHeight,
+                            ),
+                            itemBuilder: (context, item) {
+                              return SizedBox(
+                                child: TopItemComponent(
+                                  image: state.imagesGroupedSortedByDate[index]
+                                      [item],
+                                  headers: header,
+                                  showCount: false,
+                                ),
+                              );
+                            },
+                          ),
                         ),
                       ],
                     );

--- a/lib/components/image_page_comp/image_frame_container/image_frame_image_container.dart
+++ b/lib/components/image_page_comp/image_frame_container/image_frame_image_container.dart
@@ -36,7 +36,7 @@ class _ImageFrameImageContainerState extends State<ImageFrameImageContainer> {
             PageView.builder(
               controller: state.pageController,
               physics: canScroll
-                  ? AlwaysScrollableScrollPhysics()
+                  ? BouncingScrollPhysics()
                   : NeverScrollableScrollPhysics(),
               onPageChanged: (index) {
                 context

--- a/lib/components/image_page_comp/image_frame_dialog/image_frame_dialog.dart
+++ b/lib/components/image_page_comp/image_frame_dialog/image_frame_dialog.dart
@@ -35,8 +35,14 @@ class ImageFrameDialog extends StatelessWidget {
                     itemCount: state.imageFrameTimelineList.length,
                     itemBuilder: (context, index) {
                       String listText = '';
+
                       listText =
                           "${state.imageFrameTimelineList[index].dateString} ${state.imageFrameTimelineList[index].timeString}";
+
+                      if (state.imageFrameTimelineList[index].type ==
+                          UploadType.forgotShot) {
+                        listText = "Forgot Shot 🫣";
+                      }
 
                       String userID = context.read<AppBloc>().state.user.id;
 

--- a/lib/screens/album_frame.dart
+++ b/lib/screens/album_frame.dart
@@ -54,12 +54,6 @@ class AlbumFrame extends StatelessWidget {
                       return AlbumRevealTabView(arguments: arguments);
                     case AlbumPhases.open:
                       return const AlbumUnlockTabView();
-                    // case AlbumPhases.invite:
-                    //   return const InvitePage();
-                    // case AlbumPhases.unlock:
-                    //   return const AlbumUnlockTabView();
-                    // case AlbumPhases.lock:
-                    //   return const AlbumLockTabView();
                     default:
                       return const Placeholder();
                   }


### PR DESCRIPTION
Updated the timeline list in the album page so that it is sorted initially by date for those that were uploaded within the app - and then the others are sorted by forgot shot, or those taken outside of the app and uploaded.