### PR TITLE
las-404-create-timeline-and-popular-page-view

### DIFF
--- a/lib/bloc/cubit/album_frame_state.dart
+++ b/lib/bloc/cubit/album_frame_state.dart
@@ -147,6 +147,11 @@ class AlbumFrameState extends Equatable {
     return shuffled.take(25).toList();
   }
 
+  List<Photo> get popularPhotoSlider {
+    List<Photo> popular = rankedImages;
+    return popular.take(10).toList();
+  }
+
   List<List<Photo>> get imagesGroupedSortedByDate {
     Map<String, List<Photo>> mapImages = {};
     List<List<Photo>> listImages = [];

--- a/lib/components/album_comp/reveal_comps/event_guest_row.dart
+++ b/lib/components/album_comp/reveal_comps/event_guest_row.dart
@@ -30,21 +30,20 @@ class EventGuestRow extends StatelessWidget {
                 Text(
                   "Guests",
                   style: GoogleFonts.montserrat(
-                    color: Colors.white,
-                    fontSize: 18,
-                    fontWeight: FontWeight.w600,
-                  ),
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold),
                 ),
                 Icon(
                   Icons.arrow_forward_ios,
                   color: Colors.white70,
-                  size: 18,
+                  size: 16,
                 ),
               ],
             ),
           ),
         ),
-        Gap(10),
+        Gap(5),
         Container(
           height: 70,
           padding: EdgeInsets.symmetric(vertical: 5),
@@ -56,6 +55,7 @@ class EventGuestRow extends StatelessWidget {
               if (index == 0) {
                 return SizedBox(width: 0);
               }
+
               return AvatarListItem(
                 avatarURL: guestList[index - 1].avatarReq540,
                 name: guestList[index - 1].firstName,

--- a/lib/components/album_comp/reveal_comps/reveal_event_landing.dart
+++ b/lib/components/album_comp/reveal_comps/reveal_event_landing.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_photo/bloc/bloc/app_bloc.dart';
 import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
 import 'package:shared_photo/components/album_comp/empty_album_unlock.dart';
+import 'package:shared_photo/components/album_comp/image_components/top_item_component.dart';
 import 'package:shared_photo/components/album_comp/reveal_comps/event_guest_row.dart';
+import 'package:shared_photo/components/album_comp/reveal_comps/timeline_popular_section.dart';
 import 'package:shared_photo/components/album_comp/reveal_comps/trending_slideshow.dart';
+import 'package:shared_photo/components/app_comp/section_header_small.dart';
 
 class RevealEventLanding extends StatelessWidget {
   const RevealEventLanding({super.key});
@@ -13,32 +18,102 @@ class RevealEventLanding extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
       builder: (context, state) {
+        Map<String, String> header = context.read<AppBloc>().state.user.headers;
+
         return state.images.isNotEmpty
             ? Expanded(
                 child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 0.0),
-                  child: ListView(
-                    children: [
-                      Gap(5),
-                      TrendingSlideshow(
-                        slideshowPhotos: state.shuffledPhotos,
-                        albumID: state.album.albumId,
+                  padding: const EdgeInsets.symmetric(horizontal: 2.0),
+                  child: CustomScrollView(
+                    slivers: [
+                      SliverToBoxAdapter(child: Gap(6)),
+                      SliverToBoxAdapter(
+                        child: TrendingSlideshow(
+                          slideshowPhotos: state.popularPhotoSlider,
+                          albumID: state.album.albumId,
+                        ),
                       ),
-                      Gap(20),
-                      EventGuestRow(guestList: state.mostImagesUploaded),
-                      Gap(20),
-                      Container(
-                        height: 850,
-                        color: Colors.brown,
+                      SliverToBoxAdapter(child: Gap(15)),
+                      SliverToBoxAdapter(
+                          child: EventGuestRow(
+                              guestList: state.mostImagesUploaded)),
+                      SliverToBoxAdapter(child: Gap(15)),
+
+                      // SliverGrid(
+                      //   delegate: SliverChildBuilderDelegate(
+                      //     (BuildContext context, int index) {
+                      //       return TopItemComponent(
+                      //         image: state.rankedImages[index],
+                      //         showCount: false,
+                      //         headers:
+                      //             context.read<AppBloc>().state.user.headers,
+                      //       );
+                      //     },
+                      //     childCount: state.rankedImages.length,
+                      //   ),
+                      //   gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      //     crossAxisCount: 3, // Number of columns
+                      //     crossAxisSpacing: 4,
+                      //     mainAxisSpacing: 4,
+                      //   ),
+                      // ),
+                      SliverList.separated(
+                        itemCount: state.imagesGroupedSortedByDate.length,
+                        itemBuilder: (context, index) {
+                          if (state
+                              .imagesGroupedSortedByDate[index].isNotEmpty) {
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Padding(
+                                  padding: const EdgeInsets.only(bottom: 2.0),
+                                  child: SectionHeaderSmall(state
+                                      .imagesGroupedSortedByDate[index][0]
+                                      .dateString),
+                                ),
+                                GridView.builder(
+                                  shrinkWrap: true,
+                                  physics: const NeverScrollableScrollPhysics(),
+                                  itemCount: state
+                                      .imagesGroupedSortedByDate[index].length,
+                                  gridDelegate:
+                                      const SliverGridDelegateWithFixedCrossAxisCount(
+                                    crossAxisCount: 3,
+                                    mainAxisSpacing: 4,
+                                    crossAxisSpacing: 4,
+                                    //childAspectRatio: 4 / 5,
+                                  ),
+                                  itemBuilder: (context, item) {
+                                    return TopItemComponent(
+                                      image:
+                                          state.imagesGroupedSortedByDate[index]
+                                              [item],
+                                      headers: header,
+                                      showCount: false,
+                                    );
+                                  },
+                                ),
+                              ],
+                            );
+                          } else {
+                            return SizedBox.shrink();
+                          }
+                        },
+                        // physics: NeverScrollableScrollPhysics(),
+                        separatorBuilder: (context, index) {
+                          return const SizedBox(height: 0);
+                        },
                       ),
                     ],
                   ),
                 ),
               )
             : Expanded(
-                child: EmptyAlbumView(
-                  isUnlockPhase: false,
-                  album: state.album,
+                child: Center(
+                  child: EmptyAlbumView(
+                    isUnlockPhase: false,
+                    album: state.album,
+                  ),
                 ),
               );
       },

--- a/lib/components/album_comp/reveal_comps/timeline_popular_section.dart
+++ b/lib/components/album_comp/reveal_comps/timeline_popular_section.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_photo/bloc/bloc/app_bloc.dart';
+import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
+import 'package:shared_photo/components/album_comp/image_components/top_item_component.dart';
+import 'package:shared_photo/components/app_comp/section_header_small.dart';
+
+class TimelinePopularSection extends StatefulWidget {
+  const TimelinePopularSection({super.key});
+
+  @override
+  State<TimelinePopularSection> createState() => _TimelinePopularSectionState();
+}
+
+class _TimelinePopularSectionState extends State<TimelinePopularSection> {
+  double sectionHeight = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    Map<String, String> header = context.read<AppBloc>().state.user.headers;
+    return DefaultTabController(
+      length: 2,
+      child: Column(
+        children: [
+          TabBar(
+            tabAlignment: TabAlignment.start,
+            isScrollable: true,
+            labelPadding: EdgeInsets.only(right: 20),
+            labelStyle: GoogleFonts.montserrat(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+            unselectedLabelStyle: GoogleFonts.montserrat(
+              color: Colors.white54,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+            tabs: [
+              Tab(
+                text: "Popular",
+              ),
+              Tab(
+                text: "Timeline",
+              ),
+            ],
+          ),
+          Expanded(
+            flex: 2,
+            child: BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
+              builder: (context, state) {
+                return TabBarView(
+                  children: [
+                    GridView.builder(
+                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 3, // Number of columns
+                        crossAxisSpacing: 4,
+                        mainAxisSpacing: 4,
+                      ),
+                      itemBuilder: (context, index) {
+                        return TopItemComponent(
+                          image: state.rankedImages[index],
+                          showCount: false,
+                          headers: context.read<AppBloc>().state.user.headers,
+                        );
+                      },
+                      itemCount: state.rankedImages.length,
+                      physics: NeverScrollableScrollPhysics(),
+                    ),
+                    ListView.separated(
+                      itemCount: state.imagesGroupedSortedByDate.length,
+                      itemBuilder: (context, index) {
+                        if (state.imagesGroupedSortedByDate[index].isNotEmpty) {
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 12.0),
+                                child: SectionHeaderSmall(state
+                                    .imagesGroupedSortedByDate[index][0]
+                                    .dateString),
+                              ),
+                              GridView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: state
+                                    .imagesGroupedSortedByDate[index].length,
+                                gridDelegate:
+                                    const SliverGridDelegateWithFixedCrossAxisCount(
+                                  crossAxisCount: 3,
+                                  mainAxisSpacing: 4,
+                                  crossAxisSpacing: 4,
+                                  //childAspectRatio: 4 / 5,
+                                ),
+                                itemBuilder: (context, item) {
+                                  return SizedBox(
+                                    height: 100,
+                                    child: TopItemComponent(
+                                      image:
+                                          state.imagesGroupedSortedByDate[index]
+                                              [item],
+                                      headers: header,
+                                      showCount: false,
+                                    ),
+                                  );
+                                },
+                              ),
+                            ],
+                          );
+                        }
+                      },
+                      // physics: NeverScrollableScrollPhysics(),
+                      separatorBuilder: (context, index) {
+                        return const SizedBox(height: 12);
+                      },
+                    ),
+                  ],
+                );
+              },
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/album_comp/reveal_comps/trending_slideshow.dart
+++ b/lib/components/album_comp/reveal_comps/trending_slideshow.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_photo/bloc/bloc/app_bloc.dart';
 import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
 import 'package:shared_photo/bloc/cubit/image_frame_cubit.dart';
@@ -117,12 +118,11 @@ class _TrendingSlideshowState extends State<TrendingSlideshow>
               // Text(
               //   "Trending",
               //   style: GoogleFonts.montserrat(
-              //     color: Colors.white,
-              //     fontSize: 18,
-              //     fontWeight: FontWeight.w600,
-              //   ),
+              //       color: Colors.white,
+              //       fontSize: 18,
+              //       fontWeight: FontWeight.bold),
               // ),
-              // Gap(8),
+              // Gap(5),
               Stack(
                 children: [
                   AspectRatio(
@@ -226,7 +226,7 @@ class _TrendingSlideshowState extends State<TrendingSlideshow>
                                         child: index < currentIndex
                                             ? Container(
                                                 color: Colors.white,
-                                                height: 5,
+                                                height: 3,
                                               )
                                             : index == currentIndex
                                                 ? Container(
@@ -242,16 +242,16 @@ class _TrendingSlideshowState extends State<TrendingSlideshow>
                                                         ],
                                                       ),
                                                     ),
-                                                    height: 5,
+                                                    height: 3,
                                                   )
                                                 : index > currentIndex
                                                     ? Container(
                                                         color: Colors.white24,
-                                                        height: 5,
+                                                        height: 3,
                                                       )
                                                     : Container(
                                                         color: Colors.white24,
-                                                        height: 5,
+                                                        height: 3,
                                                       ),
                                       ),
                                       index != widget.slideshowPhotos.length - 1

--- a/lib/components/album_comp/unlock_comps/unlock_timeline_page.dart
+++ b/lib/components/album_comp/unlock_comps/unlock_timeline_page.dart
@@ -19,7 +19,7 @@ class UnlockTimelinePage extends StatelessWidget {
       child: CustomScrollView(
         slivers: [
           SliverPadding(
-            padding: const EdgeInsets.symmetric(horizontal: 15),
+            padding: const EdgeInsets.symmetric(horizontal: 2),
             sliver: SliverList.separated(
               itemCount: album.imagesGroupedSortedByDate.length,
               itemBuilder: (context, index) {
@@ -37,10 +37,10 @@ class UnlockTimelinePage extends StatelessWidget {
                       itemCount: album.imagesGroupedSortedByDate[index].length,
                       gridDelegate:
                           const SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: 4,
+                        crossAxisCount: 3,
                         mainAxisSpacing: 4,
                         crossAxisSpacing: 4,
-                        childAspectRatio: 4 / 5,
+                        //childAspectRatio: 4 / 5,
                       ),
                       itemBuilder: (context, item) {
                         if (album

--- a/lib/components/album_comp/util_comps/album_appbar_title.dart
+++ b/lib/components/album_comp/util_comps/album_appbar_title.dart
@@ -12,6 +12,8 @@ class AlbumAppBarTitle extends StatelessWidget implements PreferredSizeWidget {
       builder: (context, state) {
         return AppBar(
           centerTitle: true,
+          titleSpacing: 0,
+          leadingWidth: 25,
           leading: GestureDetector(
             onTap: () => Navigator.of(context).pop(),
             child: const Icon(
@@ -24,7 +26,7 @@ class AlbumAppBarTitle extends StatelessWidget implements PreferredSizeWidget {
             style: GoogleFonts.josefinSans(
               color: Colors.white,
               fontWeight: FontWeight.w600,
-              fontSize: 24,
+              fontSize: 20,
             ),
           ),
           actions: [

--- a/lib/components/album_comp/util_comps/reveal_countdown.dart
+++ b/lib/components/album_comp/util_comps/reveal_countdown.dart
@@ -65,20 +65,36 @@ class _RevealCountdownState extends State<RevealCountdown> {
   @override
   Widget build(BuildContext context) {
     calculateTimeUntilReveal();
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 00),
+    return Container(
+      decoration: BoxDecoration(
+          //color: Color.fromRGBO(181, 131, 141, 1),
+          gradient: const LinearGradient(
+            colors: [
+              // Color.fromRGBO(255, 205, 178, 1),
+              // Color.fromRGBO(255, 180, 162, 1),
+              //Color.fromRGBO(229, 152, 155, 1),
+              Color.fromRGBO(181, 131, 141, 1),
+              Color.fromRGBO(109, 104, 117, 1),
+            ],
+            begin: Alignment.bottomLeft,
+            end: Alignment.topRight,
+          ),
+          borderRadius: BorderRadius.circular(2)),
+      padding: const EdgeInsets.symmetric(vertical: 3.0, horizontal: 5.0),
+      margin: const EdgeInsets.only(bottom: 4.0, left: 2.0, right: 2.0),
       child: Builder(
         builder: (context) {
           if (widget.album.phase == AlbumPhases.open) {
             return Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Text(
                   "Reveals in",
                   style: GoogleFonts.montserrat(
                     color: Colors.white70,
                     fontWeight: FontWeight.w600,
-                    fontSize: 16,
+                    fontSize: 14,
                   ),
                 ),
                 FittedBox(
@@ -87,8 +103,8 @@ class _RevealCountdownState extends State<RevealCountdown> {
                     revealsInString(),
                     style: GoogleFonts.dmMono(
                       color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                      fontSize: 14,
                     ),
                   ),
                 )
@@ -97,21 +113,22 @@ class _RevealCountdownState extends State<RevealCountdown> {
           } else {
             return Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Text(
                   "Revealed on",
                   style: GoogleFonts.montserrat(
                     color: Colors.white70,
                     fontWeight: FontWeight.w600,
-                    fontSize: 16,
+                    fontSize: 14,
                   ),
                 ),
                 Text(
                   widget.album.revealDateTimeFormatter,
                   style: GoogleFonts.josefinSans(
                     color: Colors.white,
-                    fontWeight: FontWeight.w600,
-                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    fontSize: 14,
                   ),
                 )
               ],

--- a/lib/components/feed_comp/feed/feed_slideshow_inset.dart
+++ b/lib/components/feed_comp/feed/feed_slideshow_inset.dart
@@ -49,7 +49,7 @@ class FeedSlideshowInset extends StatelessWidget {
                                   decoration: BoxDecoration(
                                     image: DecorationImage(
                                       image: CachedNetworkImageProvider(
-                                        state.topThreeImages[index].imageReq,
+                                        state.topThreeImages[index].imageReq540,
                                         headers: headers,
                                       ),
                                       fit: BoxFit.cover,

--- a/lib/screens/album_frame.dart
+++ b/lib/screens/album_frame.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_photo/bloc/bloc/app_bloc.dart';
 import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
 import 'package:shared_photo/bloc/cubit/image_frame_cubit.dart';
 import 'package:shared_photo/components/album_comp/reveal_comps/reveal_event_landing.dart';
 import 'package:shared_photo/components/album_comp/util_comps/album_appbar_title.dart';
-import 'package:shared_photo/components/album_comp/reveal_comps/album_reveal_tab_view.dart';
 import 'package:shared_photo/components/album_comp/unlock_comps/album_unlock_tab_view.dart';
 import 'package:shared_photo/components/album_comp/util_comps/reveal_countdown.dart';
 import 'package:shared_photo/models/album.dart';


### PR DESCRIPTION
The main purpose of this commit was to add the final section to the reveal event page. This is the timeline section at the bottom of the page. Also reverted the trending_slideshow to only show the top 10 images - made some updates to the progress indicator at the top of the slideshow. Ensured all the spacing was even across the event page. Updated the countdown section to have a gradient for separation. Ensured the correct image url is getting called on the feed page.

Did not create this to reflect the figma - could not add the page view at the bottom of the event page efficiently.