### PR TITLE
las-429-invalidate-profile-picture-when-uploaded

### DIFF
--- a/lib/components/app_frame/profile_nav_element.dart
+++ b/lib/components/app_frame/profile_nav_element.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_photo/bloc/bloc/app_bloc.dart';
@@ -42,7 +43,7 @@ class ProfileNavElement extends StatelessWidget {
             ),
             child: CircleAvatar(
               backgroundImage: const AssetImage("lib/assets/placeholder.png"),
-              foregroundImage: NetworkImage(
+              foregroundImage: CachedNetworkImageProvider(
                 url,
                 headers: headers,
               ),

--- a/lib/components/profile_comp/profile_header_comps/profile_header.dart
+++ b/lib/components/profile_comp/profile_header_comps/profile_header.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -31,7 +32,7 @@ class ProfileHeader extends StatelessWidget {
                     backgroundColor: Colors.grey,
                     backgroundImage:
                         const AssetImage("lib/assets/placeholder.png"),
-                    foregroundImage: NetworkImage(
+                    foregroundImage: CachedNetworkImageProvider(
                       state.user.avatarUrl,
                       headers: state.user.headers,
                     ),

--- a/lib/screens/settings/prof_photo_frame.dart
+++ b/lib/screens/settings/prof_photo_frame.dart
@@ -16,6 +16,7 @@ class ProfPhotoFrame extends StatelessWidget {
     double devWidth = MediaQuery.of(context).size.width;
     double circleDiameter = devWidth * .25;
     ImagePicker picker = ImagePicker();
+
     return Scaffold(
       backgroundColor: Colors.black,
       appBar: AppBar(
@@ -74,9 +75,11 @@ class ProfPhotoFrame extends StatelessWidget {
                           picker.pickImage(source: ImageSource.gallery).then(
                             (value) {
                               if (value != null) {
-                                context
-                                    .read<SettingsCubit>()
-                                    .addProfileImage(value);
+                                if (context.mounted) {
+                                  context
+                                      .read<SettingsCubit>()
+                                      .addProfileImage(value);
+                                }
                               }
                             },
                           ).catchError(
@@ -99,19 +102,29 @@ class ProfPhotoFrame extends StatelessWidget {
                       ),
                       const Spacer(),
                       InkWell(
-                        onTap: () {
+                        onTap: () async {
                           if (settingsState.profileImageToUpload != null) {
-                            context
+                            await context
                                 .read<SettingsCubit>()
                                 .uploadProfilePicture()
-                                .then((value) {
-                              if (value) {
-                                context
-                                    .read<SettingsCubit>()
-                                    .clearNewImageFile();
-                                Navigator.of(context).pop();
-                              }
-                            });
+                                .then(
+                              (value) async {
+                                if (value) {
+                                  if (context.mounted) {
+                                    context
+                                        .read<SettingsCubit>()
+                                        .clearNewImageFile();
+
+                                    await CachedNetworkImage.evictFromCache(
+                                        state.user.avatarUrl);
+
+                                    if (context.mounted) {
+                                      Navigator.of(context).pop();
+                                    }
+                                  }
+                                }
+                              },
+                            );
                           }
                         },
                         child: Container(

--- a/lib/screens/settings_frame.dart
+++ b/lib/screens/settings_frame.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -62,7 +63,7 @@ class SettingsFrame extends StatelessWidget {
                             backgroundColor: Colors.white54,
                             backgroundImage:
                                 const AssetImage("lib/assets/placeholder.png"),
-                            foregroundImage: NetworkImage(
+                            foregroundImage: CachedNetworkImageProvider(
                               state.user.avatarUrl,
                               headers: state.user.headers,
                             ),


### PR DESCRIPTION
Added the evict image function after the user changes there profile picture - using the CachedNetworkImage package it still takes a second to change but it does eventually change when the app rebuilds and doesn't require a refresh. Still need to do for initial upload.