### PR TITLE
las-431-implement-leave-event-modal-ui

### DIFF
--- a/lib/components/album_comp/album_detail_comps/cover_photo_detail.dart
+++ b/lib/components/album_comp/album_detail_comps/cover_photo_detail.dart
@@ -1,0 +1,38 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_photo/bloc/bloc/app_bloc.dart';
+import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
+
+class CoverPhotoDetail extends StatelessWidget {
+  const CoverPhotoDetail({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    double height = MediaQuery.of(context).size.height;
+    return BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
+      builder: (context, state) {
+        return SizedBox(
+          height: height * .25,
+          child: AspectRatio(
+            aspectRatio: 4 / 5,
+            child: Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                color: const Color.fromRGBO(19, 19, 19, 1),
+                image: DecorationImage(
+                  image: CachedNetworkImageProvider(
+                    state.album.coverReq,
+                    headers: context.read<AppBloc>().state.user.headers,
+                    errorListener: (_) {},
+                  ),
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/components/album_comp/album_detail_comps/invite_list_detail/invite_list_button.dart
+++ b/lib/components/album_comp/album_detail_comps/invite_list_detail/invite_list_button.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
+import 'package:shared_photo/components/album_comp/album_detail_comps/invite_list_detail/invite_list_main.dart';
+
+class InviteListButton extends StatelessWidget {
+  const InviteListButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: TextButton(
+        onPressed: () => showModalBottomSheet(
+          context: context,
+          isScrollControlled: true,
+          useSafeArea: true,
+          //backgroundColor: Colors.black,
+          builder: (ctx) {
+            return BlocProvider.value(
+              value: context.read<AlbumFrameCubit>(),
+              child: const InviteListMain(),
+            );
+          },
+        ),
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: Text("Invite List"),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/album_comp/album_detail_comps/leave_delete_comps/delete_leave_event_button.dart
+++ b/lib/components/album_comp/album_detail_comps/leave_delete_comps/delete_leave_event_button.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
+import 'package:shared_photo/components/album_comp/album_detail_comps/leave_delete_comps/event_delete/delete_dialog.dart';
+import 'package:shared_photo/components/album_comp/album_detail_comps/leave_delete_comps/event_leave/leave_dialog.dart';
+import 'package:shared_photo/components/album_comp/album_detail_comps/leave_delete_comps/event_leave/transfer_dialog.dart';
+
+class DeleteLeaveEventButton extends StatelessWidget {
+  final bool isOwner;
+  final bool hasImages;
+  final bool hasGuests;
+  const DeleteLeaveEventButton({
+    super.key,
+    required this.isOwner,
+    required this.hasImages,
+    required this.hasGuests,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if ((isOwner && !hasImages) || (isOwner && !hasGuests)) {
+      return ElevatedButton(
+        onPressed: () => showDialog(
+          context: context,
+          builder: (context) {
+            return DeleteDialog();
+          },
+        ),
+        child: Text("Delete Event"),
+      );
+    } else if (isOwner) {
+      return ElevatedButton(
+        onPressed: () => showDialog(
+          context: context,
+          builder: (ctx) => BlocProvider.value(
+            value: context.read<AlbumFrameCubit>(),
+            child: const TransferDialog(),
+          ),
+        ),
+        child: Text("Leave Event"),
+      );
+    } else {
+      return ElevatedButton(
+        onPressed: () => showDialog(
+          context: context,
+          builder: (ctx) => BlocProvider.value(
+            value: context.read<AlbumFrameCubit>(),
+            child: const LeaveDialog(),
+          ),
+        ),
+        child: Text("Leave Event"),
+      );
+    }
+  }
+}

--- a/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_delete/delete_dialog.dart
+++ b/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_delete/delete_dialog.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class DeleteDialog extends StatelessWidget {
+  const DeleteDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleDialog(
+      backgroundColor: Color.fromRGBO(34, 34, 38, 1),
+      title: Center(
+        child: Text(
+          "Delete event?",
+          style: GoogleFonts.lato(
+            color: Color.fromRGBO(242, 243, 247, .75),
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+      children: [
+        SimpleDialogOption(
+          child: Text(
+            "Are you sure you want to delete the event?\n \nAll images will be permanently deleted and not recoverable.\n \nTo confirm type ‘delete’ in the box below:",
+            style: GoogleFonts.lato(
+                color: Color.fromRGBO(242, 243, 247, 1),
+                fontWeight: FontWeight.w400,
+                fontSize: 14),
+          ),
+        ),
+        SimpleDialogOption(
+          child: TextField(
+            onTapOutside: (event) =>
+                FocusManager.instance.primaryFocus?.unfocus(),
+            decoration: InputDecoration(hintText: "delete"),
+          ),
+        ),
+        Center(
+          child: SimpleDialogOption(
+            child: ElevatedButton(
+              onPressed: () {},
+              child: Text("Leave"),
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_leave/leave_dialog.dart
+++ b/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_leave/leave_dialog.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class LeaveDialog extends StatelessWidget {
+  const LeaveDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleDialog(
+      backgroundColor: Color.fromRGBO(34, 34, 38, 1),
+      title: Center(
+        child: Text(
+          "Leave event?",
+          style: GoogleFonts.lato(
+            color: Color.fromRGBO(242, 243, 247, .75),
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+      children: [
+        SimpleDialogOption(
+          child: Text(
+            "Are you sure you want to leave the event?\n \nYou’ll no longer be able to see images you have added to this event.",
+            style: GoogleFonts.lato(
+                color: Color.fromRGBO(242, 243, 247, 1),
+                fontWeight: FontWeight.w400,
+                fontSize: 14),
+          ),
+        ),
+        Center(
+          child: SimpleDialogOption(
+            child: ElevatedButton(
+              onPressed: () {},
+              child: Text("Leave Event"),
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_leave/transfer_dialog.dart
+++ b/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_leave/transfer_dialog.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gap/gap.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_photo/bloc/bloc/app_bloc.dart';
+import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
+import 'package:shared_photo/models/guest.dart';
+
+class TransferDialog extends StatefulWidget {
+  const TransferDialog({super.key});
+
+  @override
+  State<TransferDialog> createState() => _TransferDialogState();
+}
+
+class _TransferDialogState extends State<TransferDialog> {
+  double oneHeight = 250;
+  double twoHeight = 350;
+  late double height;
+  bool canLeave = false;
+
+  @override
+  void initState() {
+    super.initState();
+    height = oneHeight;
+  }
+
+  void updateDialog() {}
+
+  @override
+  Widget build(BuildContext context) {
+    String userID = context.read<AppBloc>().state.user.id;
+    return BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
+      builder: (context, state) {
+        return LayoutBuilder(builder: (context, constraints) {
+          return SimpleDialog(
+            backgroundColor: Color.fromRGBO(34, 34, 38, 1),
+            title: Center(
+              child: Text(
+                "Leave event?",
+                style: GoogleFonts.lato(
+                  color: Color.fromRGBO(242, 243, 247, .75),
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            //contentPadding: EdgeInsets.only(top: 12),
+            children: [
+              AnimatedContainer(
+                duration: Duration(milliseconds: 250),
+                height: height,
+                width: constraints.maxWidth,
+                child: Column(
+                  children: [
+                    SimpleDialogOption(
+                      child: Text(
+                        "You’ll need to transfer ownership of this album before you can leave.\n \nSelect the new owner below:",
+                        style: GoogleFonts.lato(
+                          color: Color.fromRGBO(242, 243, 247, 1),
+                          fontWeight: FontWeight.w400,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
+                    DropdownMenu<Guest>(
+                      inputDecorationTheme: InputDecorationTheme(
+                        filled: true,
+                        fillColor: Color.fromRGBO(56, 56, 60, 1),
+                        enabledBorder: OutlineInputBorder(
+                          borderSide: BorderSide(color: Colors.transparent),
+                          borderRadius: BorderRadius.circular(5),
+                        ),
+                      ),
+                      expandedInsets: EdgeInsets.symmetric(horizontal: 24),
+                      initialSelection: state.album.guests
+                          .firstWhere((guest) => guest.uid == userID),
+                      onSelected: (value) {
+                        if (value?.uid == userID) {
+                          setState(() {
+                            canLeave = false;
+                            height = oneHeight;
+                          });
+                        } else {
+                          setState(() {
+                            canLeave = true;
+                            height = twoHeight;
+                          });
+                        }
+                      },
+                      dropdownMenuEntries: state.album.guests.map(
+                        (Guest guest) {
+                          bool isOwner = guest.uid == userID;
+                          return DropdownMenuEntry(
+                            value: guest,
+                            label: guest.fullName,
+                            enabled: !isOwner,
+                          );
+                        },
+                      ).toList(),
+                    ),
+                    Gap(10),
+                    canLeave
+                        ? Expanded(
+                            child: SimpleDialogOption(
+                              child: Text(
+                                "Are you sure you want to leave the event?\n \nYou’ll no longer be able to see images you have added to this event.",
+                                style: GoogleFonts.lato(
+                                  color: Color.fromRGBO(242, 243, 247, 1),
+                                  fontWeight: FontWeight.w400,
+                                  fontSize: 14,
+                                ),
+                              ),
+                            ),
+                          )
+                        : SizedBox.shrink(),
+                    canLeave ? SizedBox.shrink() : Spacer(),
+                    Center(
+                      child: SimpleDialogOption(
+                        child: ElevatedButton(
+                          onPressed: canLeave ? () {} : null,
+                          child: Text("Leave event"),
+                        ),
+                      ),
+                    )
+                  ],
+                ),
+              ),
+            ],
+          );
+        });
+      },
+    );
+  }
+}

--- a/lib/components/album_comp/album_detail_comps/visibility_comps/edit_visibility_button.dart
+++ b/lib/components/album_comp/album_detail_comps/visibility_comps/edit_visibility_button.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
+import 'package:shared_photo/components/album_comp/album_detail_comps/visibility_comps/visibility_select_modal.dart';
+
+class EditVisibilityButton extends StatelessWidget {
+  final bool isOwner;
+  const EditVisibilityButton({super.key, required this.isOwner});
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) {
+        if (isOwner) {
+          return SizedBox(
+            width: double.infinity,
+            child: TextButton(
+              onPressed: () => showDialog(
+                context: context,
+                builder: (ctx) => BlocProvider.value(
+                  value: context.read<AlbumFrameCubit>(),
+                  child: const VisibilitySelectModal(),
+                ),
+              ),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text("Edit Visibility"),
+              ),
+            ),
+          );
+        } else {
+          return const SizedBox.shrink();
+        }
+      },
+    );
+  }
+}

--- a/lib/components/album_comp/album_detail_comps/visibility_comps/visibility_select_modal.dart
+++ b/lib/components/album_comp/album_detail_comps/visibility_comps/visibility_select_modal.dart
@@ -53,8 +53,8 @@ class _VisibilitySelectModalState extends State<VisibilitySelectModal> {
             "Select visibility:",
             textAlign: TextAlign.center,
           ),
-          titleTextStyle: GoogleFonts.montserrat(
-            color: Colors.white.withOpacity(.75),
+          titleTextStyle: GoogleFonts.lato(
+            color: Color.fromRGBO(242, 243, 247, .75),
             fontSize: 16,
             fontWeight: FontWeight.w600,
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -196,12 +196,13 @@ ThemeData darkMode() {
       surfaceTintColor: Colors.transparent,
     ),
     bottomSheetTheme: const BottomSheetThemeData(
-        backgroundColor: Color.fromRGBO(19, 19, 20, 1)),
+      backgroundColor: Color.fromRGBO(19, 19, 20, 1),
+    ),
     inputDecorationTheme: InputDecorationTheme(
       fillColor: Color.fromRGBO(34, 34, 38, 1),
       filled: true,
       hintStyle: GoogleFonts.lato(
-        color: Color.fromRGBO(242, 243, 247, .75),
+        color: Color.fromRGBO(242, 243, 247, .55),
         fontSize: 16,
         fontWeight: FontWeight.w400,
       ),

--- a/lib/screens/album_detail_frame.dart
+++ b/lib/screens/album_detail_frame.dart
@@ -1,23 +1,29 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_photo/bloc/bloc/app_bloc.dart';
+import 'package:shared_photo/bloc/bloc/profile_bloc.dart';
 import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
-import 'package:shared_photo/components/album_comp/album_detail_comps/invite_list_detail/invite_list_main.dart';
-import 'package:shared_photo/components/album_comp/album_detail_comps/visibility_comps/visibility_select_modal.dart';
+import 'package:shared_photo/components/album_comp/album_detail_comps/cover_photo_detail.dart';
+import 'package:shared_photo/components/album_comp/album_detail_comps/leave_delete_comps/delete_leave_event_button.dart';
+import 'package:shared_photo/components/album_comp/album_detail_comps/visibility_comps/edit_visibility_button.dart';
+import 'package:shared_photo/components/album_comp/album_detail_comps/invite_list_detail/invite_list_button.dart';
+import 'package:shared_photo/models/notification.dart';
 
 class AlbumDetailFrame extends StatelessWidget {
   const AlbumDetailFrame({super.key});
 
   @override
   Widget build(BuildContext context) {
-    double height = MediaQuery.of(context).size.height;
     return BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
       builder: (context, state) {
         bool isOwner =
             context.read<AppBloc>().state.user.id == state.album.albumOwner;
+        bool hasImages = state.album.images.isNotEmpty;
+        bool hasGuests = state.album.guests
+                .where((element) => element.status == RequestStatus.accepted)
+                .length >
+            1;
         return Scaffold(
           //backgroundColor: Colors.black,
           appBar: AppBar(
@@ -36,115 +42,22 @@ class AlbumDetailFrame extends StatelessWidget {
             child: Column(
               children: [
                 const Gap(45),
-                SizedBox(
-                  height: height * .25,
-                  child: AspectRatio(
-                    aspectRatio: 4 / 5,
-                    child: Container(
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        color: const Color.fromRGBO(19, 19, 19, 1),
-                        image: DecorationImage(
-                          image: CachedNetworkImageProvider(
-                            state.album.coverReq,
-                            headers: context.read<AppBloc>().state.user.headers,
-                            errorListener: (_) {},
-                          ),
-                          fit: BoxFit.cover,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+                CoverPhotoDetail(),
                 const Gap(60),
-                SizedBox(
-                  width: double.infinity,
-                  child: TextButton(
-                    onPressed: () => showModalBottomSheet(
-                      context: context,
-                      isScrollControlled: true,
-                      useSafeArea: true,
-                      //backgroundColor: Colors.black,
-                      builder: (ctx) {
-                        return BlocProvider.value(
-                          value: context.read<AlbumFrameCubit>(),
-                          child: const InviteListMain(),
-                        );
-                      },
-                    ),
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: Text("Invite List"),
-                    ),
-                  ),
-                ),
+                InviteListButton(),
                 const Gap(10),
-                isOwner
-                    ? SizedBox(
-                        width: double.infinity,
-                        child: TextButton(
-                          onPressed: () => showDialog(
-                            context: context,
-                            builder: (ctx) => BlocProvider.value(
-                              value: context.read<AlbumFrameCubit>(),
-                              child: const VisibilitySelectModal(),
-                            ),
-                          ),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text("Edit Visibility"),
-                          ),
-                        ),
-                      )
-                    : const SizedBox.shrink(),
+                EditVisibilityButton(isOwner: isOwner),
+                const Gap(10),
+                DeleteLeaveEventButton(
+                  isOwner: isOwner,
+                  hasImages: hasImages,
+                  hasGuests: hasGuests,
+                ),
               ],
             ),
           ),
         );
       },
-    );
-  }
-}
-
-class DetailItem extends StatelessWidget {
-  final String itemTitle;
-  final Color backgroundColor;
-  final VoidCallback onTap;
-  const DetailItem({
-    super.key,
-    required this.itemTitle,
-    required this.backgroundColor,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        height: 50,
-        //margin: const EdgeInsets.symmetric(horizontal: 30, vertical: 4),
-        padding: const EdgeInsets.symmetric(horizontal: 15),
-        decoration: BoxDecoration(
-          color: backgroundColor,
-          borderRadius: BorderRadius.circular(10),
-        ),
-        child: Row(
-          children: [
-            Text(
-              itemTitle,
-              style: GoogleFonts.montserrat(
-                color: Colors.white,
-                fontWeight: FontWeight.w500,
-                fontSize: 16,
-              ),
-            ),
-            // const Flex(
-            //   direction: Axis.horizontal,
-            // ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/screens/auth/login_frame.dart
+++ b/lib/screens/auth/login_frame.dart
@@ -122,7 +122,7 @@ class _LoginFrameState extends State<LoginFrame> {
                         child: TextButton(
                           onPressed: () => showDialog(
                             context: context,
-                            barrierDismissible: true,
+                            barrierDismissible: false,
                             builder: (ctx) => BlocProvider.value(
                               value: context.read<AuthCubit>(),
                               child: const ForgotPassword(),

--- a/lib/screens/friend_profile_frame.dart
+++ b/lib/screens/friend_profile_frame.dart
@@ -89,14 +89,11 @@ class _FriendProfileFrameState extends State<FriendProfileFrame> {
                       ),
                       Align(
                         alignment: Alignment.bottomCenter,
-                        child: Padding(
-                          padding: const EdgeInsets.only(bottom: 12.0),
-                          child: MonthPageView(
-                            selectedPageNotifier: selectedPageNotifier,
-                            monthList: state.eventsByDatetime.keys.toList(),
-                            minusOnePageSection: "Together",
-                            minusOneIcon: Icons.group,
-                          ),
+                        child: MonthPageView(
+                          selectedPageNotifier: selectedPageNotifier,
+                          monthList: state.eventsByDatetime.keys.toList(),
+                          minusOnePageSection: "Together",
+                          minusOneIcon: Icons.group,
                         ),
                       ),
                     ],

--- a/lib/services/image_service.dart
+++ b/lib/services/image_service.dart
@@ -172,6 +172,7 @@ class ImageService {
           // },
           onSendProgress: (int sent, int total) {
             double statusPercent = sent / total;
+
             if (statusController.isClosed == false) {
               statusController.add(statusPercent);
             }
@@ -185,6 +186,7 @@ class ImageService {
         }
         response = uploadResponse;
       }
+
       String code = response.statusCode.toString();
       String body = response.body;
 


### PR DESCRIPTION
Updated the album detail page to include a new delete/leave modal - also updated the logic to show the specific dialog depending on how where the user needed to be deleted, transfer ownership or just leave. No bloc logic.

close las-432-implement-leave-event-re-assign-model-ui
close las-436-implement-event-delete-modal-ui