### PR TITLE
las-434-create-the-bloc-logic-for-handling-event-leaving

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.ignoreCMakeListsMissing": true
+}

--- a/lib/bloc/bloc/dashboard_bloc.dart
+++ b/lib/bloc/bloc/dashboard_bloc.dart
@@ -46,6 +46,18 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
       emit(state.copyWith(activeAlbumMap: albumMap));
     });
 
+    on<RemoveAlbumInMap>(
+      (event, emit) {
+        Map<String, Album> albumMap = Map.from(state.activeAlbumMap);
+
+        Album album = event.album;
+        String key = album.albumId;
+
+        albumMap.remove(key);
+        emit(state.copyWith(activeAlbumMap: albumMap));
+      },
+    );
+
     // Stream Listeners
     dataRepository.albumStream.listen((event) {
       StreamOperation type = event.$1;
@@ -62,13 +74,15 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
 
       bool userIsOwner = album.albumOwner == user.id;
 
-      if ((userIsGuest || userIsOwner) && album.phase == AlbumPhases.open) {
+      if (((userIsGuest || userIsOwner) && album.phase == AlbumPhases.open) ||
+          type == StreamOperation.delete) {
         switch (type) {
           case StreamOperation.add:
             add(AddAlbumToMap(album: album));
           case StreamOperation.update:
             add(UpdateAlbumInMap(album: album));
           case StreamOperation.delete:
+            add(RemoveAlbumInMap(album: album));
         }
       }
     });

--- a/lib/bloc/bloc/dashboard_event.dart
+++ b/lib/bloc/bloc/dashboard_event.dart
@@ -22,3 +22,9 @@ class UpdateAlbumInMap extends DashboardEvent {
 
   const UpdateAlbumInMap({required this.album});
 }
+
+class RemoveAlbumInMap extends DashboardEvent {
+  final Album album;
+
+  const RemoveAlbumInMap({required this.album});
+}

--- a/lib/bloc/bloc/feed_bloc.dart
+++ b/lib/bloc/bloc/feed_bloc.dart
@@ -49,6 +49,25 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
       },
     );
 
+    on<RemoveEventFromList>(
+      (event, emit) {
+        Album album = event.album;
+        Map<String, Album> feedAlbumMap = Map.from(state.feedAlbumMap);
+
+        if (!feedAlbumMap.containsKey(album.albumId)) {
+          return;
+        }
+
+        if (album.visibility == AlbumVisibility.public) {
+          return;
+        }
+
+        feedAlbumMap.remove(album.albumId);
+
+        emit(state.copyWith(feedAlbumMap: feedAlbumMap));
+      },
+    );
+
     dataRepository.feedStream.listen(
       (event) {
         StreamOperation type = event.$1;
@@ -58,7 +77,25 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           case StreamOperation.add:
             add(AddAlbumsToFeed(albums: albums));
           case StreamOperation.delete:
+            break;
           case StreamOperation.update:
+            break;
+        }
+      },
+    );
+
+    dataRepository.albumStream.listen(
+      (event) {
+        StreamOperation type = event.$1;
+        Album album = event.$2;
+
+        switch (type) {
+          case StreamOperation.add:
+            break;
+          case StreamOperation.delete:
+            add(RemoveEventFromList(album: album));
+          case StreamOperation.update:
+            break;
         }
       },
     );

--- a/lib/bloc/bloc/feed_event.dart
+++ b/lib/bloc/bloc/feed_event.dart
@@ -25,6 +25,12 @@ class FeedDataRequested extends FeedEvent {
   });
 }
 
+class RemoveEventFromList extends FeedEvent {
+  final Album album;
+
+  const RemoveEventFromList({required this.album});
+}
+
 class FeedDataFetched extends FeedEvent {}
 
 class FeedDataFailed extends FeedEvent {}

--- a/lib/bloc/bloc/profile_bloc.dart
+++ b/lib/bloc/bloc/profile_bloc.dart
@@ -77,6 +77,20 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
       add(UpdateEventByDatetime());
     });
 
+    on<RemoveAlbumInMap>(
+      //TODO: Confirm why this isn't working - need to ensure this gets updated
+      (event, emit) {
+        Map<String, Album> albumMap = Map.from(state.myAlbumsMap);
+
+        Album album = event.album;
+        String key = album.albumId;
+
+        albumMap.remove(key);
+        emit(state.copyWith(myAlbumsMap: albumMap));
+        add(UpdateEventByDatetime());
+      },
+    );
+
     on<UpdateImageInAlbum>((event, emit) {
       Map<String, Album> profileAlbumMap = Map.from(state.myAlbumsMap);
 
@@ -142,9 +156,11 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
 
       switch (type) {
         case StreamOperation.add:
+          break;
         case StreamOperation.update:
           add(UpdateUser(user: user));
         case StreamOperation.delete:
+          break;
       }
     });
 
@@ -165,6 +181,7 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
           case StreamOperation.update:
             add(UpdateAlbumInMap(album: album));
           case StreamOperation.delete:
+            add(RemoveAlbumInMap(album: album));
         }
       }
     });

--- a/lib/bloc/bloc/profile_event.dart
+++ b/lib/bloc/bloc/profile_event.dart
@@ -40,6 +40,15 @@ class UpdateAlbumInMap extends ProfileEvent {
   List<Object?> get props => [album];
 }
 
+class RemoveAlbumInMap extends ProfileEvent {
+  final Album album;
+
+  const RemoveAlbumInMap({required this.album});
+
+  @override
+  List<Object?> get props => [album];
+}
+
 class UpdateImageInAlbum extends ProfileEvent {
   final ImageChange imageChange;
 

--- a/lib/bloc/cubit/album_frame_cubit.dart
+++ b/lib/bloc/cubit/album_frame_cubit.dart
@@ -7,6 +7,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:shared_photo/models/album.dart';
 import 'package:shared_photo/models/custom_exception.dart';
 import 'package:shared_photo/models/guest.dart';
+import 'package:shared_photo/models/notification.dart';
 import 'package:shared_photo/models/photo.dart';
 import 'package:shared_photo/repositories/data_repository/data_repository.dart';
 import 'package:shared_photo/repositories/realtime_repository.dart';
@@ -221,6 +222,31 @@ class AlbumFrameCubit extends Cubit<AlbumFrameState> {
 
     emit(state.copyWith(loading: false));
     return true;
+  }
+
+  Future<bool> transferAndLeaveEvent(Guest guest) async {
+    String? error;
+    bool success = false;
+    emit(state.copyWith(loading: true));
+    (success, error) =
+        await dataRepository.updateEventOwnership(albumID, guest);
+
+    if (error != null) {
+      CustomException exception = CustomException(errorString: error);
+      emit(state.copyWith(loading: false, exception: exception));
+      emit(state.copyWith(exception: CustomException.empty));
+      return success;
+    }
+
+    (success, error) = await dataRepository.deleteLeaveEvent(albumID);
+    if (error != null) {
+      CustomException exception = CustomException(errorString: error);
+      emit(state.copyWith(loading: false, exception: exception));
+      emit(state.copyWith(exception: CustomException.empty));
+      return success;
+    }
+    emit(state.copyWith(loading: false));
+    return success;
   }
 
   @override

--- a/lib/bloc/cubit/album_frame_state.dart
+++ b/lib/bloc/cubit/album_frame_state.dart
@@ -40,7 +40,8 @@ class AlbumFrameState extends Equatable {
   List<Guest> get mostImagesUploaded {
     Map<Guest, List<Photo>> mapImages = {};
 
-    for (var guest in album.guests) {
+    for (var guest in album.guests
+        .where((guest) => guest.status == RequestStatus.accepted)) {
       mapImages[guest] = [];
     }
 
@@ -64,7 +65,8 @@ class AlbumFrameState extends Equatable {
   Map<String, List<Photo>> get imagesGroupedByGuest {
     Map<String, List<Photo>> mapImages = {};
 
-    for (var guest in album.guests) {
+    for (var guest in album.guests
+        .where((guest) => guest.status == RequestStatus.accepted)) {
       mapImages[guest.uid] = [];
     }
 

--- a/lib/bloc/cubit/camera_cubit.dart
+++ b/lib/bloc/cubit/camera_cubit.dart
@@ -58,6 +58,7 @@ class CameraCubit extends HydratedCubit<CameraState> {
               addUnlockedAlbums(album);
             case StreamOperation.update:
             case StreamOperation.delete:
+              removeEventFromList(album);
           }
         }
       });
@@ -127,6 +128,14 @@ class CameraCubit extends HydratedCubit<CameraState> {
       }
       emit(state.copyWith(albumMap: albumMap));
     }
+  }
+
+  void removeEventFromList(Album album) {
+    Map<String, Album> albumMap = Map.from(state.albumMap);
+
+    albumMap.remove(album.albumId);
+
+    emit(state.copyWith(albumMap: albumMap));
   }
 
   void toggleImageInUploadList(CapturedImage image) {

--- a/lib/bloc/cubit/notification_cubit.dart
+++ b/lib/bloc/cubit/notification_cubit.dart
@@ -256,6 +256,8 @@ class NotificationCubit extends Cubit<NotificationState> {
           unseenFriendRequests: false,
         ));
         return;
+      case RequestStatus.abandoned:
+        break;
     }
   }
 
@@ -316,6 +318,17 @@ class NotificationCubit extends Cubit<NotificationState> {
             unseenAlbumInvites: false,
           ),
         );
+      case RequestStatus.abandoned:
+        Map<String, AlbumInviteNotification> albumInviteCopy =
+            Map.from(state.albumInviteMap);
+        albumInviteCopy
+            .removeWhere((key, value) => key == invite.notificationID);
+        emit(
+          state.copyWith(
+            albumInviteMap: albumInviteCopy,
+            unseenAlbumInvites: false,
+          ),
+        );
     }
   }
 
@@ -339,9 +352,9 @@ class NotificationCubit extends Cubit<NotificationState> {
         ));
 
       case StreamOperation.update:
-      // TODO: Handle this case.
+        break;
       case StreamOperation.delete:
-      // TODO: Handle this case.
+        break;
     }
   }
 
@@ -364,9 +377,9 @@ class NotificationCubit extends Cubit<NotificationState> {
         ));
 
       case StreamOperation.update:
-      // TODO: Handle this case.
+        break;
       case StreamOperation.delete:
-      // TODO: Handle this case.
+        break;
     }
   }
 }

--- a/lib/components/album_comp/album_detail_comps/invite_list_detail/current_invite_list.dart
+++ b/lib/components/album_comp/album_detail_comps/invite_list_detail/current_invite_list.dart
@@ -72,7 +72,10 @@ class CurrentInviteList extends StatelessWidget {
                                 Icons.help_outline_outlined,
                                 color: Color.fromRGBO(125, 125, 125, 1)),
                             RequestStatus.denied =>
-                              const Icon(Icons.cancel, color: Colors.red)
+                              const Icon(Icons.cancel, color: Colors.red),
+                            RequestStatus.abandoned => Icon(
+                                Icons.do_disturb_alt_rounded,
+                                color: Colors.white12)
                           }
                         ],
                       ),

--- a/lib/components/album_comp/album_detail_comps/invite_list_detail/invite_friend_page.dart
+++ b/lib/components/album_comp/album_detail_comps/invite_list_detail/invite_friend_page.dart
@@ -70,16 +70,16 @@ class InviteFriendPage extends StatelessWidget {
                                         .headers,
                                     errorListener: (_) {},
                                   ),
-                                  radius: 18,
+                                  radius: 14,
                                   onForegroundImageError: (_, __) {},
                                 ),
                                 const Gap(15),
                                 Expanded(
                                   child: Text(
                                     friendList[index].fullName,
-                                    style: GoogleFonts.josefinSans(
+                                    style: GoogleFonts.lato(
                                       color: Colors.white,
-                                      fontSize: 18,
+                                      fontSize: 14,
                                       fontWeight: FontWeight.w600,
                                     ),
                                     overflow: TextOverflow.fade,

--- a/lib/components/album_comp/album_detail_comps/invite_list_detail/invited_button.dart
+++ b/lib/components/album_comp/album_detail_comps/invite_list_detail/invited_button.dart
@@ -47,14 +47,13 @@ class _InvitedButtonState extends State<InvitedButton> {
   Widget build(BuildContext context) {
     Future<void> onTapCaller() async {
       bool success;
-      String? error;
+      //String? error;
       loading();
-      (success, error) =
-          await context.read<AlbumFrameCubit>().sendInviteToFriends(
-                widget.inviteID,
-                widget.firstName,
-                widget.lastName,
-              );
+      (success, _) = await context.read<AlbumFrameCubit>().sendInviteToFriends(
+            widget.inviteID,
+            widget.firstName,
+            widget.lastName,
+          );
       //print(success);
       if (success) {
         updateButton();

--- a/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_leave/transfer_dialog.dart
+++ b/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_leave/transfer_dialog.dart
@@ -5,6 +5,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_photo/bloc/bloc/app_bloc.dart';
 import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
 import 'package:shared_photo/models/guest.dart';
+import 'package:shared_photo/models/notification.dart';
 
 class TransferDialog extends StatefulWidget {
   const TransferDialog({super.key});
@@ -18,6 +19,7 @@ class _TransferDialogState extends State<TransferDialog> {
   double twoHeight = 350;
   late double height;
   bool canLeave = false;
+  Guest? guest;
 
   @override
   void initState() {
@@ -80,15 +82,20 @@ class _TransferDialogState extends State<TransferDialog> {
                           setState(() {
                             canLeave = false;
                             height = oneHeight;
+                            guest = null;
                           });
                         } else {
                           setState(() {
                             canLeave = true;
                             height = twoHeight;
+                            guest = value;
                           });
                         }
                       },
-                      dropdownMenuEntries: state.album.guests.map(
+                      dropdownMenuEntries: state.album.guests
+                          .where(
+                              (guest) => guest.status == RequestStatus.accepted)
+                          .map(
                         (Guest guest) {
                           bool isOwner = guest.uid == userID;
                           return DropdownMenuEntry(
@@ -118,7 +125,16 @@ class _TransferDialogState extends State<TransferDialog> {
                     Center(
                       child: SimpleDialogOption(
                         child: ElevatedButton(
-                          onPressed: canLeave ? () {} : null,
+                          onPressed: (canLeave && guest != null)
+                              ? () => context
+                                      .read<AlbumFrameCubit>()
+                                      .transferAndLeaveEvent(guest!)
+                                      .then((success) {
+                                    if (success && context.mounted) {
+                                      Navigator.of(context).pop();
+                                    }
+                                  })
+                              : null,
                           child: Text("Leave event"),
                         ),
                       ),

--- a/lib/components/feed_comp/feed/feed_list.dart
+++ b/lib/components/feed_comp/feed/feed_list.dart
@@ -13,15 +13,8 @@ class FeedList extends StatelessWidget {
         return SliverList.separated(
           itemCount: state.revealedFeedAlbumList.length,
           itemBuilder: (context, index) {
-            if (index == 0) {
-              return Padding(
-                padding: const EdgeInsets.only(top: 0.0),
-                child: FeedListItem(
-                  album: state.revealedFeedAlbumList[index],
-                ),
-              );
-            }
             return FeedListItem(
+              key: ValueKey(state.revealedFeedAlbumList[index].albumId),
               album: state.revealedFeedAlbumList[index],
             );
           },

--- a/lib/components/feed_comp/feed/feed_list_item.dart
+++ b/lib/components/feed_comp/feed/feed_list_item.dart
@@ -30,6 +30,7 @@ class FeedListItem extends StatelessWidget {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(10),
             ),
+            elevation: 0,
             child: Padding(
               padding: const EdgeInsets.all(20.0),
               child: Column(
@@ -95,6 +96,7 @@ class FeedListItem extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.only(top: 12),
                       child: BlocProvider(
+                        key: ValueKey(album.albumId),
                         lazy: false,
                         create: (context) => FeedSlideshowCubit(
                           album: album,

--- a/lib/components/feed_comp/feed/feed_slideshow_inset.dart
+++ b/lib/components/feed_comp/feed/feed_slideshow_inset.dart
@@ -67,7 +67,7 @@ class FeedSlideshowInset extends StatelessWidget {
                               decoration: BoxDecoration(
                                 image: DecorationImage(
                                   image: CachedNetworkImageProvider(
-                                    state.album.coverReq,
+                                    state.album.coverReq540,
                                     headers: headers,
                                     errorListener: (_) {},
                                   ),

--- a/lib/components/notification_comps/album_requests/album_requests_list.dart
+++ b/lib/components/notification_comps/album_requests/album_requests_list.dart
@@ -43,6 +43,8 @@ class AlbumRequestsList extends StatelessWidget {
                       );
                     case RequestStatus.denied:
                       return const SizedBox(height: 0);
+                    case RequestStatus.abandoned:
+                      return const SizedBox(height: 0);
                   }
                 },
               ),

--- a/lib/components/notification_comps/friend_requests/friend_requests_list.dart
+++ b/lib/components/notification_comps/friend_requests/friend_requests_list.dart
@@ -53,6 +53,8 @@ class FriendRequestList extends StatelessWidget {
 
                       case RequestStatus.denied:
                         return const SizedBox(height: 0);
+                      case RequestStatus.abandoned:
+                        return const SizedBox(height: 0);
                     }
                   },
                 ),

--- a/lib/models/album.dart
+++ b/lib/models/album.dart
@@ -97,13 +97,16 @@ class Album extends Equatable {
   Album copyWith({
     Map<String, Photo>? imageMap,
     AlbumVisibility? visibility,
+    String? albumOwner,
+    String? ownerFirst,
+    String? ownerLast,
   }) {
     return Album(
       albumId: albumId,
       albumName: albumName,
-      albumOwner: albumOwner,
-      ownerFirst: ownerFirst,
-      ownerLast: ownerLast,
+      albumOwner: albumOwner ?? this.albumOwner,
+      ownerFirst: ownerFirst ?? this.ownerFirst,
+      ownerLast: ownerLast ?? this.ownerLast,
       creationDateTime: creationDateTime,
       revealDateTime: revealDateTime,
       visibility: visibility ?? this.visibility,

--- a/lib/models/guest.dart
+++ b/lib/models/guest.dart
@@ -23,6 +23,8 @@ class Guest {
         status = RequestStatus.pending;
       case 'denied':
         status = RequestStatus.denied;
+      case 'abandoned':
+        status = RequestStatus.abandoned;
       default:
         status = RequestStatus.pending;
     }

--- a/lib/models/notification.dart
+++ b/lib/models/notification.dart
@@ -15,7 +15,8 @@ enum NotificationType { generic, friendRequest, albumInvite }
 enum RequestStatus {
   pending(1),
   accepted(2),
-  denied(3);
+  denied(3),
+  abandoned(4);
 
   const RequestStatus(this.val);
   final int val;

--- a/lib/repositories/notification_repository/album_invite_repo.dart
+++ b/lib/repositories/notification_repository/album_invite_repo.dart
@@ -20,6 +20,8 @@ extension AlbumInviteRepo on NotificationRepository {
         // Communicates to the notification cubit to remove
         // Also goes to the data repo to update the album if present
         _notificationController.add((StreamOperation.update, invite));
+      case RequestStatus.abandoned:
+        break;
     }
   }
 

--- a/lib/repositories/notification_repository/friend_request_repo.dart
+++ b/lib/repositories/notification_repository/friend_request_repo.dart
@@ -12,6 +12,9 @@ extension FriendRequestRepo on NotificationRepository {
         _notificationController.add((StreamOperation.update, request));
 
       case RequestStatus.denied:
+        break;
+      case RequestStatus.abandoned:
+        break;
     }
   }
 

--- a/lib/repositories/notification_repository/notification_repository.dart
+++ b/lib/repositories/notification_repository/notification_repository.dart
@@ -92,6 +92,8 @@ class NotificationRepository {
                     .removeWhere((key, value) => key == noti.notificationID);
               }
               _notificationController.add((StreamOperation.delete, noti));
+            case RequestStatus.abandoned:
+              break;
           }
         case EngagementNotification:
           EngagementNotification noti = notification as EngagementNotification;

--- a/lib/repositories/realtime_repository.dart
+++ b/lib/repositories/realtime_repository.dart
@@ -84,6 +84,9 @@ class RealtimeRepository {
       return;
     }
 
+    // Currently the only web socket messages that are being sent are
+    // user engagement related - no event/album updates such as delete, new owner,
+    // Timeline changes, etc are being propogated through this channel.
     String type = jsonData["type"];
 
     switch (type) {

--- a/lib/screens/album_detail_frame.dart
+++ b/lib/screens/album_detail_frame.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:shared_photo/bloc/bloc/app_bloc.dart';
-import 'package:shared_photo/bloc/bloc/profile_bloc.dart';
 import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
 import 'package:shared_photo/components/album_comp/album_detail_comps/cover_photo_detail.dart';
 import 'package:shared_photo/components/album_comp/album_detail_comps/leave_delete_comps/delete_leave_event_button.dart';
@@ -15,15 +14,17 @@ class AlbumDetailFrame extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    String userID = context.read<AppBloc>().state.user.id;
     return BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
       builder: (context, state) {
-        bool isOwner =
-            context.read<AppBloc>().state.user.id == state.album.albumOwner;
-        bool hasImages = state.album.images.isNotEmpty;
+        bool isOwner = userID == state.album.albumOwner;
+        bool hasImages = state.album.imageMap.isNotEmpty;
         bool hasGuests = state.album.guests
                 .where((element) => element.status == RequestStatus.accepted)
                 .length >
             1;
+        bool activeInAlbum = state.album.guests.any((element) =>
+            element.uid == userID && element.status == RequestStatus.accepted);
         return Scaffold(
           //backgroundColor: Colors.black,
           appBar: AppBar(
@@ -43,16 +44,30 @@ class AlbumDetailFrame extends StatelessWidget {
               children: [
                 const Gap(45),
                 CoverPhotoDetail(),
-                const Gap(60),
-                InviteListButton(),
-                const Gap(10),
-                EditVisibilityButton(isOwner: isOwner),
-                const Gap(10),
-                DeleteLeaveEventButton(
-                  isOwner: isOwner,
-                  hasImages: hasImages,
-                  hasGuests: hasGuests,
-                ),
+                Builder(
+                  builder: (context) {
+                    if (activeInAlbum) {
+                      return Column(
+                        children: [
+                          const Gap(60),
+                          InviteListButton(),
+                          const Gap(10),
+                          EditVisibilityButton(isOwner: isOwner),
+                          const Gap(10),
+                          DeleteLeaveEventButton(
+                            isOwner: isOwner,
+                            hasImages: hasImages,
+                            hasGuests: hasGuests,
+                          ),
+                        ],
+                      );
+                    } else {
+                      return SizedBox(
+                        width: double.infinity,
+                      );
+                    }
+                  },
+                )
               ],
             ),
           ),

--- a/lib/services/album_service.dart
+++ b/lib/services/album_service.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:shared_photo/bloc/cubit/create_album_cubit.dart';
 import 'package:shared_photo/models/album.dart';
-import 'package:shared_photo/models/guest.dart';
 import 'package:http/http.dart' as http;
 import 'dart:developer' as developer;
 
@@ -174,32 +173,32 @@ class AlbumService {
     }
   }
 
-  static Future<List<Guest>> updateGuestList(
-      String token, String albumID) async {
-    List<Guest> guests = [];
+  // static Future<List<Guest>> updateGuestList(
+  //     String token, String albumID) async {
+  //   List<Guest> guests = [];
 
-    String urlString = "${dotenv.env['URL']}/album/guests?album_id=$albumID";
-    Uri url = Uri.parse(urlString);
+  //   String urlString = "${dotenv.env['URL']}/album/guests?album_id=$albumID";
+  //   Uri url = Uri.parse(urlString);
 
-    final Map<String, String> headers = {'Authorization': 'Bearer $token'};
+  //   final Map<String, String> headers = {'Authorization': 'Bearer $token'};
 
-    try {
-      final response = await http.get(url, headers: headers);
+  //   try {
+  //     final response = await http.get(url, headers: headers);
 
-      if (response.statusCode == 200) {
-        final responseBody = response.body;
-        final jsonData = json.decode(responseBody);
+  //     if (response.statusCode == 200) {
+  //       final responseBody = response.body;
+  //       final jsonData = json.decode(responseBody);
 
-        for (var item in jsonData) {
-          guests.add(Guest.fromMap(item));
-        }
-      }
-      return guests;
-    } catch (e) {
-      developer.log(e.toString());
-      return guests;
-    }
-  }
+  //       for (var item in jsonData) {
+  //         guests.add(Guest.fromMap(item));
+  //       }
+  //     }
+  //     return guests;
+  //   } catch (e) {
+  //     developer.log(e.toString());
+  //     return guests;
+  //   }
+  // }
 
   static Future<(bool, String?)> updateAlbumVisibility(
       String token, String albumID, String visibility) async {
@@ -211,6 +210,51 @@ class AlbumService {
 
     try {
       final response = await http.patch(url, headers: headers);
+
+      if (response.statusCode == 200) {
+        return (true, null);
+      }
+      String code = response.statusCode.toString();
+      String body = response.body;
+      return (false, "$code: $body");
+    } catch (e) {
+      developer.log(e.toString());
+      return (false, e.toString());
+    }
+  }
+
+  static Future<(bool, String?)> updateEventOwnership(
+      String token, String userID, String albumID) async {
+    String urlString =
+        "${dotenv.env['URL']}/user/album?user_id=$userID&album_id=$albumID";
+    final Map<String, String> headers = {'Authorization': 'Bearer $token'};
+
+    Uri url = Uri.parse(urlString);
+
+    try {
+      final response = await http.patch(url, headers: headers);
+
+      if (response.statusCode == 200) {
+        return (true, null);
+      }
+      String code = response.statusCode.toString();
+      String body = response.body;
+      return (false, "$code: $body");
+    } catch (e) {
+      developer.log(e.toString());
+      return (false, e.toString());
+    }
+  }
+
+  static Future<(bool, String?)> deleteLeaveEvent(
+      String token, String albumID) async {
+    String urlString = "${dotenv.env['URL']}/user/album?album_id=$albumID";
+    final Map<String, String> headers = {'Authorization': 'Bearer $token'};
+
+    Uri url = Uri.parse(urlString);
+
+    try {
+      final response = await http.delete(url, headers: headers);
 
       if (response.statusCode == 200) {
         return (true, null);


### PR DESCRIPTION
This commit includes all of the functionality to support leaving/deleting an album. The actual deleting/leaving needs to be buttoned up as some cubits/blocs are not receiving the update but the framework is here and it is configured with the backend to operate properly (i.e. added abandoned as an enum). Also started digging into the duplicated items on the sliverlist problem.