### PR TITLE
las-437-manage-bloc-for-event-delete

### DIFF
--- a/lib/bloc/cubit/album_frame_cubit.dart
+++ b/lib/bloc/cubit/album_frame_cubit.dart
@@ -29,7 +29,7 @@ class AlbumFrameCubit extends Cubit<AlbumFrameState> {
             album: Album.empty,
           ),
         ) {
-    // Fetch Album to Initalize
+    // Fetch Album to Initialize
     initializeAlbum();
 
     realtimeRepository.openAlbumChannelWebSocket(albumID);
@@ -66,11 +66,15 @@ class AlbumFrameCubit extends Cubit<AlbumFrameState> {
   void initializeAlbum() async {
     emit(state.copyWith(loading: true));
 
-    Album updatedAlbum = await dataRepository.getAlbumByID(albumID);
+    Album? updatedAlbum = await dataRepository.getAlbumByID(albumID);
+
+    if (updatedAlbum == null) {
+      return;
+    }
 
     emit(state.copyWith(
       album: updatedAlbum,
-      images: List.from(updatedAlbum.images),
+      images: List.from(updatedAlbum!.images),
       loading: false,
     ));
 
@@ -239,6 +243,22 @@ class AlbumFrameCubit extends Cubit<AlbumFrameState> {
     }
 
     (success, error) = await dataRepository.deleteLeaveEvent(albumID);
+    if (error != null) {
+      CustomException exception = CustomException(errorString: error);
+      emit(state.copyWith(loading: false, exception: exception));
+      emit(state.copyWith(exception: CustomException.empty));
+      return success;
+    }
+    emit(state.copyWith(loading: false));
+    return success;
+  }
+
+  Future<bool> deleteEvent() async {
+    String? error;
+    bool success = false;
+    emit(state.copyWith(loading: true));
+
+    (success, error) = await dataRepository.deleteEvent(albumID);
     if (error != null) {
       CustomException exception = CustomException(errorString: error);
       emit(state.copyWith(loading: false, exception: exception));

--- a/lib/components/album_comp/album_detail_comps/leave_delete_comps/delete_leave_event_button.dart
+++ b/lib/components/album_comp/album_detail_comps/leave_delete_comps/delete_leave_event_button.dart
@@ -22,8 +22,11 @@ class DeleteLeaveEventButton extends StatelessWidget {
       return ElevatedButton(
         onPressed: () => showDialog(
           context: context,
-          builder: (context) {
-            return DeleteDialog();
+          builder: (ctx) {
+            return BlocProvider.value(
+              value: context.read<AlbumFrameCubit>(),
+              child: DeleteDialog(),
+            );
           },
         ),
         child: Text("Delete Event"),

--- a/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_delete/delete_dialog.dart
+++ b/lib/components/album_comp/album_detail_comps/leave_delete_comps/event_delete/delete_dialog.dart
@@ -1,49 +1,97 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_photo/bloc/cubit/album_frame_cubit.dart';
 
-class DeleteDialog extends StatelessWidget {
+class DeleteDialog extends StatefulWidget {
   const DeleteDialog({super.key});
 
   @override
+  State<DeleteDialog> createState() => _DeleteDialogState();
+}
+
+class _DeleteDialogState extends State<DeleteDialog> {
+  bool confirmed = false;
+
+  void checkText(String text) {
+    if (text == 'delete') {
+      setState(() {
+        confirmed = true;
+      });
+    } else {
+      setState(() {
+        confirmed = false;
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return SimpleDialog(
-      backgroundColor: Color.fromRGBO(34, 34, 38, 1),
-      title: Center(
-        child: Text(
-          "Delete event?",
-          style: GoogleFonts.lato(
-            color: Color.fromRGBO(242, 243, 247, .75),
-            fontSize: 16,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-      ),
-      children: [
-        SimpleDialogOption(
-          child: Text(
-            "Are you sure you want to delete the event?\n \nAll images will be permanently deleted and not recoverable.\n \nTo confirm type ‘delete’ in the box below:",
-            style: GoogleFonts.lato(
-                color: Color.fromRGBO(242, 243, 247, 1),
-                fontWeight: FontWeight.w400,
-                fontSize: 14),
-          ),
-        ),
-        SimpleDialogOption(
-          child: TextField(
-            onTapOutside: (event) =>
-                FocusManager.instance.primaryFocus?.unfocus(),
-            decoration: InputDecoration(hintText: "delete"),
-          ),
-        ),
-        Center(
-          child: SimpleDialogOption(
-            child: ElevatedButton(
-              onPressed: () {},
-              child: Text("Leave"),
+    return BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
+      builder: (context, state) {
+        return Stack(
+          children: [
+            SimpleDialog(
+              backgroundColor: Color.fromRGBO(34, 34, 38, 1),
+              title: Center(
+                child: Text(
+                  "Delete event?",
+                  style: GoogleFonts.lato(
+                    color: Color.fromRGBO(242, 243, 247, .75),
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              children: [
+                SimpleDialogOption(
+                  child: Text(
+                    "Are you sure you want to delete the event?\n \nAll images will be permanently deleted and not recoverable.\n \nTo confirm type ‘delete’ in the box below:",
+                    style: GoogleFonts.lato(
+                        color: Color.fromRGBO(242, 243, 247, 1),
+                        fontWeight: FontWeight.w400,
+                        fontSize: 14),
+                  ),
+                ),
+                SimpleDialogOption(
+                  child: TextField(
+                    onChanged: (text) => checkText(text),
+                    onTapOutside: (event) =>
+                        FocusManager.instance.primaryFocus?.unfocus(),
+                    decoration: InputDecoration(hintText: "delete"),
+                  ),
+                ),
+                Center(
+                  child: SimpleDialogOption(
+                    child: ElevatedButton(
+                      onPressed: confirmed
+                          ? () => context
+                                  .read<AlbumFrameCubit>()
+                                  .deleteEvent()
+                                  .then((success) {
+                                if (success && context.mounted) {
+                                  Navigator.of(context)
+                                      .popUntil(ModalRoute.withName('/'));
+                                }
+                              })
+                          : null,
+                      child: Text("Delete"),
+                    ),
+                  ),
+                )
+              ],
             ),
-          ),
-        )
-      ],
+            state.loading
+                ? Container(
+                    color: Colors.black54,
+                    child: Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  )
+                : SizedBox.shrink(),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/components/album_comp/empty_album_unlock.dart
+++ b/lib/components/album_comp/empty_album_unlock.dart
@@ -17,63 +17,78 @@ class EmptyAlbumView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        Text(
-          "There’s nothing here 🙃",
-          style: GoogleFonts.lato(
-            color: Colors.white,
-            fontSize: 20,
-            fontWeight: FontWeight.w500,
+    return Builder(builder: (context) {
+      if (album.albumId == '') {
+        return Center(
+          child: Text(
+            "There’s nothing here 🙃",
+            style: GoogleFonts.lato(
+              color: Colors.white,
+              fontSize: 20,
+              fontWeight: FontWeight.w500,
+            ),
           ),
-        ),
-        const Gap(25),
-        isUnlockPhase
-            ? Column(
-                children: [
-                  ElevatedButton(
-                    onPressed: () {
-                      Navigator.of(context).pop("showCamera");
-                    },
-                    child: Text(
-                      "Snap a pic",
-                      style: TextStyle(fontSize: 18),
+        );
+      } else {
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              "There’s nothing here 🙃",
+              style: GoogleFonts.lato(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            const Gap(25),
+            isUnlockPhase
+                ? Column(
+                    children: [
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.of(context).pop("showCamera");
+                        },
+                        child: Text(
+                          "Snap a pic",
+                          style: TextStyle(fontSize: 18),
+                        ),
+                      ),
+                      const Gap(15),
+                      Text(
+                        "or",
+                        style: GoogleFonts.josefinSans(
+                          color: Colors.white54,
+                          fontSize: 24,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  )
+                : const Gap(0),
+            TextButton(
+              onPressed: () => showModalBottomSheet(
+                context: context,
+                isScrollControlled: true,
+                useSafeArea: true,
+                builder: (ctx) {
+                  return BlocProvider(
+                    create: (context) => CameraCubit(
+                      dataRepository: context.read<DataRepository>(),
+                      user: context.read<AppBloc>().state.user,
+                      mode: UploadMode.singleAlbum,
+                      album: album,
                     ),
-                  ),
-                  const Gap(15),
-                  Text(
-                    "or",
-                    style: GoogleFonts.josefinSans(
-                      color: Colors.white54,
-                      fontSize: 24,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
-              )
-            : const Gap(0),
-        TextButton(
-          onPressed: () => showModalBottomSheet(
-            context: context,
-            isScrollControlled: true,
-            useSafeArea: true,
-            builder: (ctx) {
-              return BlocProvider(
-                create: (context) => CameraCubit(
-                  dataRepository: context.read<DataRepository>(),
-                  user: context.read<AppBloc>().state.user,
-                  mode: UploadMode.singleAlbum,
-                  album: album,
-                ),
-                child: const CapturedImageListScreen(),
-              );
-            },
-          ),
-          child: Text("Add forgot shot"),
-        )
-      ],
-    );
+                    child: const CapturedImageListScreen(),
+                  );
+                },
+              ),
+              child: Text("Add forgot shot"),
+            )
+          ],
+        );
+      }
+    });
   }
 }

--- a/lib/components/album_comp/reveal_comps/reveal_event_landing.dart
+++ b/lib/components/album_comp/reveal_comps/reveal_event_landing.dart
@@ -18,88 +18,90 @@ class RevealEventLanding extends StatelessWidget {
       builder: (context, state) {
         Map<String, String> header = context.read<AppBloc>().state.user.headers;
 
-        return state.images.isNotEmpty
-            ? Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                  child: CustomScrollView(
-                    slivers: [
-                      SliverToBoxAdapter(child: Gap(6)),
-                      SliverToBoxAdapter(
-                        child: BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
-                          builder: (context, state) {
-                            return TrendingSlideshow(
-                              slideshowPhotos:
-                                  state.rankedImages.take(10).toList(),
-                              albumID: state.album.albumId,
-                            );
-                          },
-                        ),
-                      ),
-                      SliverToBoxAdapter(child: Gap(15)),
-                      SliverToBoxAdapter(
-                          child: EventGuestRow(
-                              guestList: state.mostImagesUploaded)),
-                      SliverToBoxAdapter(child: Gap(15)),
-                      SliverList.separated(
-                        itemCount: state.imagesGroupedSortedByDate.length,
-                        itemBuilder: (context, index) {
-                          if (state
-                              .imagesGroupedSortedByDate[index].isNotEmpty) {
-                            return Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.only(bottom: 2.0),
-                                  child: SectionHeaderSmall(state
-                                      .imagesGroupedSortedByDate[index][0]
-                                      .dateString),
-                                ),
-                                GridView.builder(
-                                  shrinkWrap: true,
-                                  physics: const NeverScrollableScrollPhysics(),
-                                  itemCount: state
-                                      .imagesGroupedSortedByDate[index].length,
-                                  gridDelegate:
-                                      const SliverGridDelegateWithFixedCrossAxisCount(
-                                    crossAxisCount: 3,
-                                    mainAxisSpacing: 4,
-                                    crossAxisSpacing: 4,
-                                    //childAspectRatio: 4 / 5,
-                                  ),
-                                  itemBuilder: (context, item) {
-                                    return TopItemComponent(
-                                      image:
-                                          state.imagesGroupedSortedByDate[index]
-                                              [item],
-                                      headers: header,
-                                      showCount: false,
-                                    );
-                                  },
-                                ),
-                              ],
-                            );
-                          } else {
-                            return SizedBox.shrink();
-                          }
-                        },
-                        // physics: NeverScrollableScrollPhysics(),
-                        separatorBuilder: (context, index) {
-                          return const SizedBox(height: 0);
+        return Builder(builder: (context) {
+          if (state.images.isNotEmpty) {
+            return Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 5.0),
+                child: CustomScrollView(
+                  slivers: [
+                    SliverToBoxAdapter(child: Gap(6)),
+                    SliverToBoxAdapter(
+                      child: BlocBuilder<AlbumFrameCubit, AlbumFrameState>(
+                        builder: (context, state) {
+                          return TrendingSlideshow(
+                            slideshowPhotos:
+                                state.rankedImages.take(10).toList(),
+                            albumID: state.album.albumId,
+                          );
                         },
                       ),
-                    ],
-                  ),
+                    ),
+                    SliverToBoxAdapter(child: Gap(15)),
+                    SliverToBoxAdapter(
+                        child:
+                            EventGuestRow(guestList: state.mostImagesUploaded)),
+                    SliverToBoxAdapter(child: Gap(15)),
+                    SliverList.separated(
+                      itemCount: state.imagesGroupedSortedByDate.length,
+                      itemBuilder: (context, index) {
+                        if (state.imagesGroupedSortedByDate[index].isNotEmpty) {
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 2.0),
+                                child: SectionHeaderSmall(state
+                                    .imagesGroupedSortedByDate[index][0]
+                                    .dateString),
+                              ),
+                              GridView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: state
+                                    .imagesGroupedSortedByDate[index].length,
+                                gridDelegate:
+                                    const SliverGridDelegateWithFixedCrossAxisCount(
+                                  crossAxisCount: 3,
+                                  mainAxisSpacing: 4,
+                                  crossAxisSpacing: 4,
+                                  //childAspectRatio: 4 / 5,
+                                ),
+                                itemBuilder: (context, item) {
+                                  return TopItemComponent(
+                                    image: state
+                                        .imagesGroupedSortedByDate[index][item],
+                                    headers: header,
+                                    showCount: false,
+                                  );
+                                },
+                              ),
+                            ],
+                          );
+                        } else {
+                          return SizedBox.shrink();
+                        }
+                      },
+                      // physics: NeverScrollableScrollPhysics(),
+                      separatorBuilder: (context, index) {
+                        return const SizedBox(height: 0);
+                      },
+                    ),
+                  ],
                 ),
-              )
-            : Expanded(
-                child: Center(
-                  child: EmptyAlbumView(
-                    isUnlockPhase: false,
-                    album: state.album,
-                  ),
+              ),
+            );
+          } else {
+            return Expanded(
+              child: Center(
+                child: EmptyAlbumView(
+                  isUnlockPhase: false,
+                  album: state.album,
                 ),
-              );
+              ),
+            );
+          }
+        });
       },
     );
   }


### PR DESCRIPTION
Added the service call to the delete endpoint to handle a user outright deleting an album, this is then handled throughout the blocs by removing where necessary. Does not get push to other devices - so also implemented error handling for deleted albums or non-existent albums. This also is handled for albums where the user does not have permission. Also updated the leave repo call so that it only deletes the album from the blocs if it is a private or friends only album (friends only since I can't check friend status within the repo.